### PR TITLE
refactor: externalize demo data

### DIFF
--- a/Frontend
+++ b/Frontend
@@ -8,6 +8,9 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Progress } from "@/components/ui/progress";
+import { MUSHROOMS } from "./src/data/mushrooms";
+import { DEMO_ZONES } from "./src/data/zones";
+import { LEGEND } from "./src/data/legend";
 
 // Palette & typographies adaptées au thème sombre
 const BTN = "rounded-xl bg-neutral-300 text-neutral-900 hover:bg-neutral-200";
@@ -25,25 +28,7 @@ function MushroomIcon(props){
   );
 }
 
-const MUSHROOMS = [
-  { id: "cepe", name: "Cèpe de Bordeaux", latin: "Boletus edulis", edible: true, season: "Août – Novembre", habitat: "Feuillus & conifères, sols acides, 200–1200 m, lisières et clairières", weatherIdeal: "Pluies modérées suivies de 3–5 jours doux (12–20°C), vent faible", description: "Chapeau brun-noisette, pied ventru réticulé, tubes blancs devenant verdâtres, chair blanche", culinary: "Excellente. Poêlé, en fricassée, séchage possible", cookingTips: "Saisir à feu vif dans un peu de matière grasse, ne pas laver à grande eau (brosse + chiffon)", dishes: ["Omelette aux cèpes", "Poêlée de cèpes persillés", "Tagliatelles aux cèpes", "Cèpes rôtis au four"], confusions: ["Bolet amer (Tylopilus felleus)", "Bolets à pores rouges (toxiques)"], picking: "Couper au couteau, reboucher le trou, prélever raisonnablement", photo: "https://images.unsplash.com/photo-1603296196270-937b36cf47b1?q=80&w=1600&auto=format&fit=crop" },
-  { id: "girolle", name: "Girolle (Chanterelle)", latin: "Cantharellus cibarius", edible: true, season: "Juin – Octobre", habitat: "Bois de conifères & feuillus, mousses, pentes bien drainées", weatherIdeal: "Alternance d'averses et de beaux jours, 14–22°C", description: "Chapeau jaune cône-ombiliqué, plis décurrents, odeur fruitée d'abricot", culinary: "Excellente. Sautés courts, risotto, pickles", cookingTips: "Déposer en fin de cuisson pour conserver le croquant, éviter l'excès d'eau", dishes: ["Risotto aux girolles", "Volaille sauce girolles", "Tartine forestière", "Pickles de girolles"], confusions: ["Clitocybe de l'olivier (toxique)", "Fausse girolle (Hygrophoropsis aurantiaca)"], picking: "Prélever les plus développées, laisser les jeunes", photo: "https://images.unsplash.com/photo-1631460615580-bbbc9efeb800?q=80&w=1600&auto=format&fit=crop" },
-  { id: "morille", name: "Morille commune", latin: "Morchella esculenta", edible: true, season: "Mars – Mai", habitat: "Lisières, vergers, ripisylves, sols calcaires", weatherIdeal: "Redoux printanier après pluies, 8–18°C", description: "Chapeau alvéolé en nid d'abeille, pied blanc-creme, chair creuse", culinary: "Excellente mais TOUJOURS bien cuite", cookingTips: "Sécher possible. Réhydrater puis cuire longuement. Jamais crue", dishes: ["Morilles à la crème", "Poulet aux morilles", "Pâtes aux morilles", "Tartes salées aux morilles"], confusions: ["Gyromitre (toxique)", "Morillons (autres Morchella)"], picking: "Gants recommandés pour la cueillette; longue cuisson obligatoire", photo: "https://images.unsplash.com/photo-1587307360679-f20b5cbd9e03?q=80&w=1600&auto=format&fit=crop" }
-];
-
-const DEMO_ZONES = [
-  { id: "zone-alpage", name: "Clairière des Alpages", score: 88, species: { cepe: 90, girolle: 75, morille: 0 }, trend: "⬈ amélioration", coords: [45.9, 6.6] },
-  { id: "zone-ripisylve", name: "Ripisylve du Vieux Pont", score: 72, species: { cepe: 40, girolle: 55, morille: 85 }, trend: "⬊ en baisse", coords: [45.7, 5.9] },
-  { id: "zone-lisiere", name: "Grande Lisière Sud", score: 53, species: { cepe: 60, girolle: 50, morille: 15 }, trend: "→ stable", coords: [45.6, 6.1] }
-];
-
-const LEGEND = [
-  { label: ">85", color: "bg-emerald-700" },
-  { label: "84–75", color: "bg-emerald-600" },
-  { label: "74–50", color: "bg-yellow-600" },
-  { label: "49–35", color: "bg-orange-600" },
-  { label: "34–25", color: "bg-red-600" }
-];
+// Données déplacées dans /src/data
 
 function classNames(...c){return c.filter(Boolean).join(" ");}
 

--- a/src/data/legend.ts
+++ b/src/data/legend.ts
@@ -1,0 +1,15 @@
+export interface LegendItem {
+  label: string;
+  color: string;
+}
+
+export const LEGEND: LegendItem[] = [
+  { label: ">85", color: "bg-emerald-700" },
+  { label: "84–75", color: "bg-emerald-600" },
+  { label: "74–50", color: "bg-yellow-600" },
+  { label: "49–35", color: "bg-orange-600" },
+  { label: "34–25", color: "bg-red-600" }
+];
+
+export default LEGEND;
+

--- a/src/data/mushrooms.ts
+++ b/src/data/mushrooms.ts
@@ -1,0 +1,25 @@
+export interface Mushroom {
+  id: string;
+  name: string;
+  latin: string;
+  edible: boolean;
+  season: string;
+  habitat: string;
+  weatherIdeal: string;
+  description: string;
+  culinary: string;
+  cookingTips: string;
+  dishes: string[];
+  confusions: string[];
+  picking: string;
+  photo: string;
+}
+
+export const MUSHROOMS: Mushroom[] = [
+  { id: "cepe", name: "Cèpe de Bordeaux", latin: "Boletus edulis", edible: true, season: "Août – Novembre", habitat: "Feuillus & conifères, sols acides, 200–1200 m, lisières et clairières", weatherIdeal: "Pluies modérées suivies de 3–5 jours doux (12–20°C), vent faible", description: "Chapeau brun-noisette, pied ventru réticulé, tubes blancs devenant verdâtres, chair blanche", culinary: "Excellente. Poêlé, en fricassée, séchage possible", cookingTips: "Saisir à feu vif dans un peu de matière grasse, ne pas laver à grande eau (brosse + chiffon)", dishes: ["Omelette aux cèpes", "Poêlée de cèpes persillés", "Tagliatelles aux cèpes", "Cèpes rôtis au four"], confusions: ["Bolet amer (Tylopilus felleus)", "Bolets à pores rouges (toxiques)"], picking: "Couper au couteau, reboucher le trou, prélever raisonnablement", photo: "https://images.unsplash.com/photo-1603296196270-937b36cf47b1?q=80&w=1600&auto=format&fit=crop" },
+  { id: "girolle", name: "Girolle (Chanterelle)", latin: "Cantharellus cibarius", edible: true, season: "Juin – Octobre", habitat: "Bois de conifères & feuillus, mousses, pentes bien drainées", weatherIdeal: "Alternance d'averses et de beaux jours, 14–22°C", description: "Chapeau jaune cône-ombiliqué, plis décurrents, odeur fruitée d'abricot", culinary: "Excellente. Sautés courts, risotto, pickles", cookingTips: "Déposer en fin de cuisson pour conserver le croquant, éviter l'excès d'eau", dishes: ["Risotto aux girolles", "Volaille sauce girolles", "Tartine forestière", "Pickles de girolles"], confusions: ["Clitocybe de l'olivier (toxique)", "Fausse girolle (Hygrophoropsis aurantiaca)"], picking: "Prélever les plus développées, laisser les jeunes", photo: "https://images.unsplash.com/photo-1631460615580-bbbc9efeb800?q=80&w=1600&auto=format&fit=crop" },
+  { id: "morille", name: "Morille commune", latin: "Morchella esculenta", edible: true, season: "Mars – Mai", habitat: "Lisières, vergers, ripisylves, sols calcaires", weatherIdeal: "Redoux printanier après pluies, 8–18°C", description: "Chapeau alvéolé en nid d'abeille, pied blanc-creme, chair creuse", culinary: "Excellente mais TOUJOURS bien cuite", cookingTips: "Sécher possible. Réhydrater puis cuire longuement. Jamais crue", dishes: ["Morilles à la crème", "Poulet aux morilles", "Pâtes aux morilles", "Tartes salées aux morilles"], confusions: ["Gyromitre (toxique)", "Morillons (autres Morchella)"], picking: "Gants recommandés pour la cueillette; longue cuisson obligatoire", photo: "https://images.unsplash.com/photo-1587307360679-f20b5cbd9e03?q=80&w=1600&auto=format&fit=crop" }
+];
+
+export default MUSHROOMS;
+

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -1,0 +1,17 @@
+export interface Zone {
+  id: string;
+  name: string;
+  score: number;
+  species: Record<string, number>;
+  trend: string;
+  coords: [number, number];
+}
+
+export const DEMO_ZONES: Zone[] = [
+  { id: "zone-alpage", name: "Clairière des Alpages", score: 88, species: { cepe: 90, girolle: 75, morille: 0 }, trend: "⬈ amélioration", coords: [45.9, 6.6] },
+  { id: "zone-ripisylve", name: "Ripisylve du Vieux Pont", score: 72, species: { cepe: 40, girolle: 55, morille: 85 }, trend: "⬊ en baisse", coords: [45.7, 5.9] },
+  { id: "zone-lisiere", name: "Grande Lisière Sud", score: 53, species: { cepe: 60, girolle: 50, morille: 15 }, trend: "→ stable", coords: [45.6, 6.1] }
+];
+
+export default DEMO_ZONES;
+

--- a/src/services/dataLoader.ts
+++ b/src/services/dataLoader.ts
@@ -1,0 +1,33 @@
+import { MUSHROOMS } from "../data/mushrooms";
+import { DEMO_ZONES } from "../data/zones";
+import { LEGEND } from "../data/legend";
+
+/**
+ * Service de chargement des données.
+ * Tente de récupérer les informations depuis des fichiers JSON
+ * et retombe sur les données statiques si la requête échoue.
+ */
+export async function loadMushrooms() {
+  try {
+    const res = await fetch("/data/mushrooms.json");
+    if (res.ok) return await res.json();
+  } catch {}
+  return MUSHROOMS;
+}
+
+export async function loadZones() {
+  try {
+    const res = await fetch("/data/zones.json");
+    if (res.ok) return await res.json();
+  } catch {}
+  return DEMO_ZONES;
+}
+
+export async function loadLegend() {
+  try {
+    const res = await fetch("/data/legend.json");
+    if (res.ok) return await res.json();
+  } catch {}
+  return LEGEND;
+}
+


### PR DESCRIPTION
## Summary
- move mushroom, zone, and legend data into dedicated modules
- import demo data modules in Frontend component
- add dataLoader service to allow future API/JSON loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ee06661883298df58786d822d97c