### PR TITLE
feat: add global app context

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useReducer } from "react";
+import type { Spot } from "../types";
+
+type Prefs = { units: string; theme: string; gps: boolean };
+type Alerts = { optimum: boolean; newZone: boolean };
+
+interface AppState {
+  prefs: Prefs;
+  alerts: Alerts;
+  mySpots: Spot[];
+}
+
+type Action =
+  | { type: "setPrefs"; prefs: Partial<Prefs> }
+  | { type: "setAlerts"; alerts: Partial<Alerts> }
+  | { type: "addSpot"; spot: Spot }
+  | { type: "updateSpot"; spot: Spot };
+
+const initialState: AppState = {
+  prefs: { units: "métriques", theme: "auto", gps: true },
+  alerts: { optimum: true, newZone: false },
+  mySpots: [],
+};
+
+function reducer(state: AppState, action: Action): AppState {
+  switch (action.type) {
+    case "setPrefs":
+      return { ...state, prefs: { ...state.prefs, ...action.prefs } };
+    case "setAlerts":
+      return { ...state, alerts: { ...state.alerts, ...action.alerts } };
+    case "addSpot":
+      return { ...state, mySpots: [action.spot, ...state.mySpots] };
+    case "updateSpot":
+      return {
+        ...state,
+        mySpots: state.mySpots.map((s) => (s.id === action.spot.id ? action.spot : s)),
+      };
+    default:
+      return state;
+  }
+}
+
+const AppContext = createContext<{ state: AppState; dispatch: React.Dispatch<Action> } | undefined>(
+  undefined
+);
+
+export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return <AppContext.Provider value={{ state, dispatch }}>{children}</AppContext.Provider>;
+};
+
+export function useAppContext() {
+  const ctx = useContext(AppContext);
+  if (!ctx) {
+    throw new Error("useAppContext must be used within AppProvider");
+  }
+  return ctx;
+}
+

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -6,8 +6,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
 import { ToggleRow } from "../components/ToggleRow";
 import { SelectRow } from "../components/SelectRow";
+import { useAppContext } from "../context/AppContext";
 
-export default function SettingsScene({ alerts, setAlerts, prefs, setPrefs, onOpenPacks, onBack }: { alerts: any; setAlerts: (v: any) => void; prefs: any; setPrefs: (v: any) => void; onOpenPacks: () => void; onBack: () => void }) {
+export default function SettingsScene({ onOpenPacks, onBack }: { onOpenPacks: () => void; onBack: () => void }) {
+  const { state, dispatch } = useAppContext();
+  const { alerts, prefs } = state;
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3 space-y-3">
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label="Retour">
@@ -29,17 +32,17 @@ export default function SettingsScene({ alerts, setAlerts, prefs, setPrefs, onOp
       <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
         <CardHeader><CardTitle className={T_PRIMARY}>Alertes</CardTitle></CardHeader>
         <CardContent className="space-y-2">
-          <ToggleRow label="Optimum prévu" checked={alerts.optimum} onChange={(v) => setAlerts((a: any) => ({ ...a, optimum: v }))} />
-          <ToggleRow label="Nouvelle zone proche" checked={alerts.newZone} onChange={(v) => setAlerts((a: any) => ({ ...a, newZone: v }))} />
+          <ToggleRow label="Optimum prévu" checked={alerts.optimum} onChange={(v) => dispatch({ type: "setAlerts", alerts: { optimum: v } })} />
+          <ToggleRow label="Nouvelle zone proche" checked={alerts.newZone} onChange={(v) => dispatch({ type: "setAlerts", alerts: { newZone: v } })} />
         </CardContent>
       </Card>
 
       <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
         <CardHeader><CardTitle className={T_PRIMARY}>Préférences</CardTitle></CardHeader>
         <CardContent className="space-y-2">
-          <SelectRow label="Unités" value={prefs.units} options={["métriques", "impériales"]} onChange={(v) => setPrefs((p: any) => ({ ...p, units: v }))} />
-          <SelectRow label="Thème" value={prefs.theme} options={["auto", "clair", "sombre"]} onChange={(v) => setPrefs((p: any) => ({ ...p, theme: v }))} />
-          <ToggleRow label="GPS" checked={prefs.gps} onChange={(v) => setPrefs((p: any) => ({ ...p, gps: v }))} />
+          <SelectRow label="Unités" value={prefs.units} options={["métriques", "impériales"]} onChange={(v) => dispatch({ type: "setPrefs", prefs: { units: v } })} />
+          <SelectRow label="Thème" value={prefs.theme} options={["auto", "clair", "sombre"]} onChange={(v) => dispatch({ type: "setPrefs", prefs: { theme: v } })} />
+          <ToggleRow label="GPS" checked={prefs.gps} onChange={(v) => dispatch({ type: "setPrefs", prefs: { gps: v } })} />
         </CardContent>
       </Card>
 

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -7,8 +7,11 @@ import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tok
 import { CreateSpotModal } from "../components/CreateSpotModal";
 import { EditSpotModal } from "../components/EditSpotModal";
 import { SpotDetailsModal } from "../components/SpotDetailsModal";
+import { useAppContext } from "../context/AppContext";
 
-export default function SpotsScene({ spots, onRoute, onCreate, onBack, onUpdateSpot }: { spots: any[]; onRoute: () => void; onCreate: (s: any) => void; onBack: () => void; onUpdateSpot: (s: any) => void }) {
+export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; onBack: () => void }) {
+  const { state, dispatch } = useAppContext();
+  const spots = state.mySpots;
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<any>(null);
   const [details, setDetails] = useState<any>(null);
@@ -57,7 +60,10 @@ export default function SpotsScene({ spots, onRoute, onCreate, onBack, onUpdateS
       {createOpen && (
         <CreateSpotModal
           onClose={() => setCreateOpen(false)}
-          onCreate={(spot) => { onCreate(spot); setCreateOpen(false); }}
+          onCreate={(spot) => {
+            dispatch({ type: "addSpot", spot });
+            setCreateOpen(false);
+          }}
         />
       )}
 
@@ -65,7 +71,10 @@ export default function SpotsScene({ spots, onRoute, onCreate, onBack, onUpdateS
         <EditSpotModal
           spot={editing}
           onClose={() => setEditing(null)}
-          onSave={(u) => { onUpdateSpot(u); setEditing(null); }}
+          onSave={(u) => {
+            dispatch({ type: "updateSpot", spot: u });
+            setEditing(null);
+          }}
         />
       )}
 


### PR DESCRIPTION
## Summary
- add AppContext with reducer to manage prefs, alerts and spots
- wrap application with provider and dispatch context actions
- consume shared state in SettingsScene and SpotsScene

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'framer-motion', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898f7dd0c8c832984f8141d9032188c