### PR TITLE
feat: add bilingual support with language settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import SettingsScene from "./scenes/SettingsScene";
 import DownloadScene from "./scenes/DownloadScene";
 import { AppProvider, useAppContext } from "./context/AppContext";
 import DaySlider from "./components/DaySlider";
+import { useT } from "./i18n";
 
 export default function MycoExplorerApp() {
   return (
@@ -40,6 +41,7 @@ function AppContent() {
   const [gpsFollow, setGpsFollow] = useState(false);
 
   const { dispatch } = useAppContext();
+  const { t } = useT();
 
   const goToScene = useCallback((next: number) => {
     setScene(next);
@@ -64,7 +66,7 @@ function AppContent() {
             clearInterval(id);
             setTimeout(() => {
               setDownloading(false);
-              setToast({ type: "success", text: "Carte téléchargée et prête hors‑ligne" });
+              setToast({ type: "success", text: t("Carte téléchargée et prête hors‑ligne") });
               goToScene(2);
             }, 500);
           }
@@ -117,11 +119,11 @@ function AppContent() {
                       rating: 5,
                       last: today,
                       history: [
-                        { date: today, rating: 5, note: "Créé", photos: [MUSHROOMS[1].photo] },
+                        { date: today, rating: 5, note: t("Créé"), photos: [MUSHROOMS[1].photo] },
                       ],
                     } as Spot,
                   });
-                  setToast({ type: "success", text: "Coin ajouté" });
+                  setToast({ type: "success", text: t("Coin ajouté") });
                 }}
                 onOpenShroom={(id) => {
                   setSelectedMushroom(
@@ -137,7 +139,34 @@ function AppContent() {
           {scene === 6 && <PickerScene key="s6" items={filteredMushrooms} search={search} setSearch={setSearch} onPick={(m) => { setSelectedMushroom(m); goToScene(7); }} onBack={goBack} />}
           {scene === 7 && <MushroomScene key="s7" item={selectedMushroom} onSeeZones={() => goToScene(2)} onBack={goBack} />}
             {scene === 8 && <SettingsScene key="s8" onOpenPacks={() => goToScene(9)} onBack={goBack} />}
-          {scene === 9 && <DownloadScene key="s9" packSize={packSize} setPackSize={setPackSize} deviceFree={deviceFree} setDeviceFree={setDeviceFree} includeRelief={includeRelief} setIncludeRelief={setIncludeRelief} includeWeather={includeWeather} setIncludeWeather={setIncludeWeather} downloading={downloading} dlProgress={dlProgress} onStart={() => { if (packSize > deviceFree) { setToast({ type: "warn", text: `Espace insuffisant. Libérez ${packSize - deviceFree} Mo` }); } else { setDownloading(true); setDlProgress(0); } }} onCancel={() => goToScene(2)} onBack={goBack} />}
+          {scene === 9 && (
+            <DownloadScene
+              key="s9"
+              packSize={packSize}
+              setPackSize={setPackSize}
+              deviceFree={deviceFree}
+              setDeviceFree={setDeviceFree}
+              includeRelief={includeRelief}
+              setIncludeRelief={setIncludeRelief}
+              includeWeather={includeWeather}
+              setIncludeWeather={setIncludeWeather}
+              downloading={downloading}
+              dlProgress={dlProgress}
+              onStart={() => {
+                if (packSize > deviceFree) {
+                  setToast({
+                    type: "warn",
+                    text: t("Espace insuffisant. Libérez {n} Mo", { n: packSize - deviceFree }),
+                  });
+                } else {
+                  setDownloading(true);
+                  setDlProgress(0);
+                }
+              }}
+              onCancel={() => goToScene(2)}
+              onBack={goBack}
+            />
+          )}
         </AnimatePresence>
       </main>
     </div>

--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -5,11 +5,13 @@ import { Input } from "@/components/ui/input";
 import { MUSHROOMS } from "../data/mushrooms";
 import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { StarRating } from "./StarRating";
+import { useT } from "../i18n";
 
 export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; onCreate: (spot: any) => void }) {
   const today = new Date().toISOString().slice(0, 10);
   const overlayRef = useRef<HTMLDivElement | null>(null);
-  const [name, setName] = useState("Mon nouveau coin");
+  const { t } = useT();
+  const [name, setName] = useState(t("Mon nouveau coin"));
   const [species, setSpecies] = useState<string[]>(["cepe"]);
   const [rating, setRating] = useState(4);
   const [last, setLast] = useState(today);
@@ -29,7 +31,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
 
   const create = () => {
     const cover = photos[0] || MUSHROOMS[0].photo;
-    const history = [{ date: last, rating, note: "Création", photos: photos.slice(0, 3) }];
+    const history = [{ date: last, rating, note: t("Création"), photos: photos.slice(0, 3) }];
     onCreate({ id: Date.now(), name, species, rating, last, location, cover, photos: photos.length ? photos : [cover], history });
   };
 
@@ -37,26 +39,44 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
     <div ref={overlayRef} onClick={handleOutside} className="fixed inset-0 z-50 bg-black/70 grid place-items-center p-3">
       <div className="w-full max-w-2xl bg-neutral-900 border border-neutral-800 rounded-2xl p-4">
         <div className="flex items-center justify-between mb-2">
-          <div className={`text-lg font-semibold ${T_PRIMARY}`}>Nouveau coin</div>
+          <div className={`text-lg font-semibold ${T_PRIMARY}`}>{t("Nouveau coin")}</div>
           <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
         </div>
 
         <div className="space-y-3">
-          <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nom du coin" className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`} />
-          <Input value={location} onChange={(e) => setLocation(e.target.value)} placeholder="Localisation (coordonnées ou lieu)" className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`} />
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t("Nom du coin")}
+            className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+          />
+          <Input
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder={t("Localisation (coordonnées ou lieu)")}
+            className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+          />
 
           <div>
-            <div className={`text-sm mb-1 ${T_PRIMARY}`}>Champignons trouvés</div>
+            <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Champignons trouvés")}</div>
             <div className="flex flex-wrap gap-2 mb-2">
               {species.map((id) => (
                 <span key={id} className="inline-flex items-center gap-1 bg-neutral-800 border border-neutral-700 rounded-full px-2 py-1 text-xs">
                   <span className={T_PRIMARY}>{MUSHROOMS.find((m) => m.id === id)?.name.split(" ")[0]}</span>
-                  <button onClick={() => setSpecies((list) => list.filter((x) => x !== id))} className="text-neutral-400 hover:text-neutral-200" aria-label="supprimer"><X className="w-3 h-3" /></button>
+                  <button
+                    onClick={() => setSpecies((list) => list.filter((x) => x !== id))}
+                    className="text-neutral-400 hover:text-neutral-200"
+                    aria-label={t("supprimer")}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
                 </span>
               ))}
             </div>
             <select onChange={(e) => { const v = e.target.value; if (v) setSpecies((list) => list.includes(v) ? list : [...list, v]); }} value="" className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
-              <option value="" disabled>Ajouter un champignon…</option>
+              <option value="" disabled>
+                {t("Ajouter un champignon…")}
+              </option>
               {MUSHROOMS.filter((m) => !species.includes(m.id)).map((m) => (
                 <option key={m.id} value={m.id}>{m.name}</option>
               ))}
@@ -64,24 +84,27 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
           </div>
 
           <div>
-            <div className={`text-sm ${T_PRIMARY}`}>Dernière visite</div>
+            <div className={`text-sm ${T_PRIMARY}`}>{t("Dernière visite")}</div>
             <div className="mt-1">
               <input type="date" value={last} onChange={(e) => setLast(e.target.value)} className="w-full bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100" />
             </div>
           </div>
 
           <div className="flex items-center gap-2">
-            <span className={`text-sm ${T_MUTED}`}>Note</span>
+            <span className={`text-sm ${T_MUTED}`}>{t("Note")}</span>
             <StarRating value={rating} onSelectIndex={(i) => setRating(5 - i)} />
             <span className={`text-xs ${T_SUBTLE}`}>{rating}/5</span>
           </div>
 
           <div className="pt-2 border-t border-neutral-800">
             <div className="flex items-center justify-between mb-2">
-              <div className={`text-sm ${T_PRIMARY}`}>Photos</div>
+              <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
               <label className="inline-flex items-center">
                 <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
-                <Button type="button" className={BTN}><Images className="w-4 h-4 mr-2" />Importer des photos</Button>
+                <Button type="button" className={BTN}>
+                  <Images className="w-4 h-4 mr-2" />
+                  {t("Importer des photos")}
+                </Button>
               </label>
             </div>
             {photos.length > 0 && (
@@ -94,8 +117,12 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
           </div>
 
           <div className="flex items-center gap-2 justify-end">
-            <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>Annuler</Button>
-            <Button className={BTN} onClick={create}>Créer</Button>
+            <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>
+              {t("Annuler")}
+            </Button>
+            <Button className={BTN} onClick={create}>
+              {t("Créer")}
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/DaySlider.tsx
+++ b/src/components/DaySlider.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { useAppContext } from "../context/AppContext";
+import { useT } from "../i18n";
 
 export default function DaySlider() {
   const { state, dispatch } = useAppContext();
+  const { t } = useT();
   return (
     <div className="p-3">
       <input
@@ -13,7 +15,10 @@ export default function DaySlider() {
         onChange={(e) => dispatch({ type: "setDay", day: parseInt(e.target.value, 10) })}
         className="w-full"
       />
-      <div className="text-center text-xs mt-1">J{state.day >= 0 ? "+" : ""}{state.day}</div>
+      <div className="text-center text-xs mt-1">
+        {t("J")} {state.day >= 0 ? "+" : ""}
+        {state.day}
+      </div>
     </div>
   );
 }

--- a/src/components/EditSpotModal.tsx
+++ b/src/components/EditSpotModal.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { MUSHROOMS } from "../data/mushrooms";
 import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { StarRating } from "./StarRating";
+import { useT } from "../i18n";
 
 export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: () => void; onSave: (s: any) => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -14,6 +15,7 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
   const [last, setLast] = useState(spot.last || new Date().toISOString().slice(0, 10));
   const [location, setLocation] = useState(spot.location || "");
   const [photos, setPhotos] = useState<string[]>(spot.photos || [spot.cover].filter(Boolean));
+  const { t } = useT();
 
   const importImages = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
@@ -29,16 +31,26 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
     <div ref={overlayRef} onClick={handleOutside} className="fixed inset-0 z-50 bg-black/70 grid place-items-center p-3">
       <div className="w-full max-w-2xl bg-neutral-900 border border-neutral-800 rounded-2xl p-4">
         <div className="flex items-center justify-between mb-2">
-          <div className={`text-lg font-semibold ${T_PRIMARY}`}>Modifier le coin</div>
+          <div className={`text-lg font-semibold ${T_PRIMARY}`}>{t("Modifier le coin")}</div>
           <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
         </div>
 
         <div className="grid md:grid-cols-2 gap-3">
           <div className="space-y-2">
-            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nom" className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`} />
-            <Input value={location} onChange={(e) => setLocation(e.target.value)} placeholder="Localisation" className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`} />
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t("Nom")}
+              className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+            />
+            <Input
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder={t("Localisation")}
+              className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+            />
             <div className="flex items-center gap-2">
-              <span className={`text-sm ${T_MUTED}`}>Note</span>
+              <span className={`text-sm ${T_MUTED}`}>{t("Note")}</span>
               <StarRating value={rating} onSelectIndex={(i) => setRating(5 - i)} />
               <span className={`text-xs ${T_SUBTLE}`}>{rating}/5</span>
             </div>
@@ -46,24 +58,39 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
 
           <div className="space-y-2">
             <div>
-              <div className={`text-sm mb-1 ${T_PRIMARY}`}>Champignons trouvés</div>
+              <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Champignons trouvés")}</div>
               <div className="flex flex-wrap gap-2 mb-2">
                 {species.map((id) => (
                   <span key={id} className="inline-flex items-center gap-1 bg-neutral-800 border border-neutral-700 rounded-full px-2 py-1 text-xs">
                     <span className={T_PRIMARY}>{MUSHROOMS.find((m) => m.id === id)?.name.split(" ")[0]}</span>
-                    <button onClick={() => setSpecies((list) => list.filter((x) => x !== id))} className="text-neutral-400 hover:text-neutral-200" aria-label="supprimer"><X className="w-3 h-3" /></button>
+                    <button
+                      onClick={() => setSpecies((list) => list.filter((x) => x !== id))}
+                      className="text-neutral-400 hover:text-neutral-200"
+                      aria-label={t("supprimer")}
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
                   </span>
                 ))}
               </div>
-              <select onChange={(e) => { const v = e.target.value; if (v) setSpecies((list) => list.includes(v) ? list : [...list, v]); }} value="" className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
-                <option value="" disabled>Ajouter un champignon…</option>
+              <select
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v) setSpecies((list) => (list.includes(v) ? list : [...list, v]));
+                }}
+                value=""
+                className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100"
+              >
+                <option value="" disabled>
+                  {t("Ajouter un champignon…")}
+                </option>
                 {MUSHROOMS.filter((m) => !species.includes(m.id)).map((m) => (
                   <option key={m.id} value={m.id}>{m.name}</option>
                 ))}
               </select>
             </div>
             <div>
-              <div className={`text-sm ${T_PRIMARY}`}>Dernière visite</div>
+              <div className={`text-sm ${T_PRIMARY}`}>{t("Dernière visite")}</div>
               <div className="mt-1">
                 <input type="date" value={last} onChange={(e) => setLast(e.target.value)} className="w-full bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100" />
               </div>
@@ -73,10 +100,13 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
 
         <div className="mt-3 pt-3 border-t border-neutral-800">
           <div className="flex items-center justify-between mb-2">
-            <div className={`text-sm ${T_PRIMARY}`}>Photos</div>
+            <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
             <label className="inline-flex items-center">
               <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
-              <Button type="button" className={BTN}><Images className="w-4 h-4 mr-2" />Importer des photos</Button>
+              <Button type="button" className={BTN}>
+                <Images className="w-4 h-4 mr-2" />
+                {t("Importer des photos")}
+              </Button>
             </label>
           </div>
           {photos.length > 0 && (
@@ -89,8 +119,15 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
         </div>
 
         <div className="mt-3 flex items-center gap-2 justify-end">
-          <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>Annuler</Button>
-          <Button className={BTN} onClick={() => onSave({ ...spot, name, rating, species, last, location, cover: photos[0] || spot.cover, photos })}>Enregistrer</Button>
+          <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>
+            {t("Annuler")}
+          </Button>
+          <Button
+            className={BTN}
+            onClick={() => onSave({ ...spot, name, rating, species, last, location, cover: photos[0] || spot.cover, photos })}
+          >
+            {t("Enregistrer")}
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/SelectRow.tsx
+++ b/src/components/SelectRow.tsx
@@ -1,13 +1,29 @@
 import React from "react";
 import { T_PRIMARY } from "../styles/tokens";
 
-export function SelectRow({ label, value, options, onChange }: { label: string; value: string; options: string[]; onChange: (v: string) => void }) {
+export function SelectRow({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (v: string) => void;
+}) {
   return (
     <div className="flex items-center justify-between gap-3">
       <div className={T_PRIMARY}>{label}</div>
-      <select value={value} onChange={(e) => onChange(e.target.value)} className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100"
+      >
         {options.map((o) => (
-          <option key={o}>{o}</option>
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
         ))}
       </select>
     </div>

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from "react";
 import { X, MapPin, Plus, Pencil, Maximize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { useT } from "../i18n";
 
 export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -10,6 +11,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
   const [history, setHistory] = useState(
     spot.history || (spot.visits || []).map((d: string) => ({ date: d, rating: spot.rating, note: "", photos: [] }))
   );
+  const { t } = useT();
 
   const handleOutside = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === overlayRef.current) onClose();
@@ -23,27 +25,35 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
     <div ref={overlayRef} onClick={handleOutside} className="fixed inset-0 z-50 bg-black/70 grid place-items-center p-3">
       <div className="w-full max-w-3xl bg-neutral-900 border border-neutral-800 rounded-2xl p-4">
         <div className="flex items-center justify-between mb-3">
-          <div className={`text-lg font-semibold ${T_PRIMARY}`}>Historique du coin</div>
+          <div className={`text-lg font-semibold ${T_PRIMARY}`}>{t("Historique du coin")}</div>
           <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
         </div>
 
         <div className="relative h-48 rounded-xl overflow-hidden border border-neutral-800 bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)]">
-          <div className={`absolute top-2 left-2 px-2 py-1 rounded-lg text-xs bg-neutral-900/70 border border-neutral-800 ${T_PRIMARY}`}><MapPin className="w-3 h-3 inline mr-1" />Carte du coin</div>
+          <div className={`absolute top-2 left-2 px-2 py-1 rounded-lg text-xs bg-neutral-900/70 border border-neutral-800 ${T_PRIMARY}`}>
+            <MapPin className="w-3 h-3 inline mr-1" />
+            {t("Carte du coin")}
+          </div>
         </div>
-        <p className={`text-xs mt-2 ${T_SUBTLE}`}>La carte affiche l'historique complet avec détails.</p>
+        <p className={`text-xs mt-2 ${T_SUBTLE}`}>{t("La carte affiche l'historique complet avec détails.")}</p>
 
         <div className="mt-3">
           <div className="flex items-center justify-between mb-2">
-            <div className={`text-sm ${T_PRIMARY}`}>Visites</div>
-            <Button onClick={addVisit} className={BTN}><Plus className="w-4 h-4 mr-2" />Ajouter une cueillette</Button>
+            <div className={`text-sm ${T_PRIMARY}`}>{t("Visites")}</div>
+            <Button onClick={addVisit} className={BTN}>
+              <Plus className="w-4 h-4 mr-2" />
+              {t("Ajouter une cueillette")}
+            </Button>
           </div>
           <div className="space-y-2">
-            {history.length === 0 && <div className={T_MUTED}>Aucune visite enregistrée.</div>}
+            {history.length === 0 && <div className={T_MUTED}>{t("Aucune visite enregistrée.")}</div>}
             {history.map((h, i) => (
               <div key={i} className="flex items-start justify-between bg-neutral-900 border border-neutral-800 rounded-xl p-2">
                 <div>
                   <div className={`text-sm ${T_PRIMARY}`}>{h.date}</div>
-                  <div className={`text-xs ${T_MUTED}`}>Note: {h.rating ?? "–"}/5 {h.note ? `• ${h.note}` : ""}</div>
+                  <div className={`text-xs ${T_MUTED}`}>
+                    {t("Note:")} {h.rating ?? "–"}/5 {h.note ? `• ${h.note}` : ""}
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   {h.photos && h.photos.length > 0 && (
@@ -53,7 +63,9 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
                       ))}
                     </div>
                   )}
-                  <Button variant="ghost" size="icon" className={BTN_GHOST_ICON} aria-label="modifier"><Pencil className="w-4 h-4" /></Button>
+                  <Button variant="ghost" size="icon" className={BTN_GHOST_ICON} aria-label={t("modifier")}>
+                    <Pencil className="w-4 h-4" />
+                  </Button>
                 </div>
               </div>
             ))}
@@ -61,9 +73,9 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
         </div>
 
         <div className="mt-3">
-          <div className={`text-sm mb-2 ${T_PRIMARY}`}>Galerie</div>
+          <div className={`text-sm mb-2 ${T_PRIMARY}`}>{t("Galerie")}</div>
           {photos.length === 0 ? (
-            <div className={T_MUTED}>Aucune photo.</div>
+            <div className={T_MUTED}>{t("Aucune photo.")}</div>
           ) : (
             <div className="grid grid-cols-3 gap-2">
               {photos.slice(0, 5).map((p: string, i: number) => (
@@ -75,7 +87,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
               ))}
               {photos.length > 5 && (
                 <button onClick={() => setLightbox({ open: true, index: 5 })} className="relative grid place-items-center rounded-xl border border-neutral-800 bg-neutral-900/60">
-                  <span className={`text-sm ${T_PRIMARY}`}>+{photos.length - 5} photos</span>
+                  <span className={`text-sm ${T_PRIMARY}`}>+{photos.length - 5} {t("photos")}</span>
                 </button>
               )}
             </div>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useReducer } from "react";
 import type { Spot } from "../types";
 
-type Prefs = { units: string; theme: string; gps: boolean };
+type Prefs = { units: string; theme: string; gps: boolean; lang: string };
 type Alerts = { optimum: boolean; newZone: boolean };
 
 interface AppState {
@@ -19,7 +19,7 @@ type Action =
   | { type: "setDay"; day: number };
 
 const initialState: AppState = {
-  prefs: { units: "métriques", theme: "auto", gps: true },
+  prefs: { units: "métriques", theme: "auto", gps: true, lang: "fr" },
   alerts: { optimum: true, newZone: false },
   mySpots: [],
   day: 0,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,202 @@
+export const TRANSLATIONS: Record<string, { fr: string; en: string }> = {
+  "Réglages": { fr: "Réglages", en: "Settings" },
+  "Carte téléchargée et prête hors‑ligne": {
+    fr: "Carte téléchargée et prête hors‑ligne",
+    en: "Map downloaded and ready offline",
+  },
+  "Créé": { fr: "Créé", en: "Created" },
+  "Coin ajouté": { fr: "Coin ajouté", en: "Spot added" },
+  "Espace insuffisant. Libérez {n} Mo": {
+    fr: "Espace insuffisant. Libérez {n} Mo",
+    en: "Not enough space. Free {n} MB",
+  },
+  "Retour": { fr: "Retour", en: "Back" },
+  "Mes coins": { fr: "Mes coins", en: "My spots" },
+  "Nouveau coin": { fr: "Nouveau coin", en: "New spot" },
+  "Aucun coin enregistré.": { fr: "Aucun coin enregistré.", en: "No spot saved." },
+  "modifier": { fr: "modifier", en: "edit" },
+  "Espèces :": { fr: "Espèces :", en: "Species:" },
+  "Dernière visite :": { fr: "Dernière visite :", en: "Last visit:" },
+  "Itinéraire": { fr: "Itinéraire", en: "Route" },
+  "Données stockées localement. Accès hors‑ligne.": {
+    fr: "Données stockées localement. Accès hors‑ligne.",
+    en: "Data stored locally. Offline access.",
+  },
+  "Sélectionnez une zone…": { fr: "Sélectionnez une zone…", en: "Select a zone…" },
+  "Icônes météo (démo)": { fr: "Icônes météo (démo)", en: "Weather icons (demo)" },
+  "Comestibles probables": { fr: "Comestibles probables", en: "Likely edibles" },
+  "Score {sc}%": { fr: "Score {sc}%", en: "Score {sc}%" },
+  "Y aller": { fr: "Y aller", en: "Go" },
+  "Ajouter à mes coins": { fr: "Ajouter à mes coins", en: "Add to my spots" },
+  "Prévisions locales hors‑ligne (7 jours) disponibles pour 3 champignons inclus.": {
+    fr: "Prévisions locales hors‑ligne (7 jours) disponibles pour 3 champignons inclus.",
+    en: "Offline local forecasts (7 days) available for 3 included mushrooms.",
+  },
+  "Modifier le coin": { fr: "Modifier le coin", en: "Edit spot" },
+  "Nom": { fr: "Nom", en: "Name" },
+  "Localisation": { fr: "Localisation", en: "Location" },
+  "Note": { fr: "Note", en: "Rating" },
+  "Champignons trouvés": { fr: "Champignons trouvés", en: "Found mushrooms" },
+  "supprimer": { fr: "supprimer", en: "remove" },
+  "Ajouter un champignon…": { fr: "Ajouter un champignon…", en: "Add a mushroom…" },
+  "Dernière visite": { fr: "Dernière visite", en: "Last visit" },
+  "Photos": { fr: "Photos", en: "Photos" },
+  "Importer des photos": { fr: "Importer des photos", en: "Import photos" },
+  "Annuler": { fr: "Annuler", en: "Cancel" },
+  "Enregistrer": { fr: "Enregistrer", en: "Save" },
+  "Rechercher un lieu…": { fr: "Rechercher un lieu…", en: "Search a place…" },
+  "GPS": { fr: "GPS", en: "GPS" },
+  "Ma position": { fr: "Ma position", en: "My location" },
+  "Légende": { fr: "Légende", en: "Legend" },
+  "Hors ligne : affichage des zones optimales Cèpe, Girolle, Morille.": {
+    fr: "Hors ligne : affichage des zones optimales Cèpe, Girolle, Morille.",
+    en: "Offline: display optimal zones for Porcini, Chanterelle, Morel.",
+  },
+  "Historique du coin": { fr: "Historique du coin", en: "Spot history" },
+  "Carte du coin": { fr: "Carte du coin", en: "Spot map" },
+  "La carte affiche l'historique complet avec détails.": {
+    fr: "La carte affiche l'historique complet avec détails.",
+    en: "The map shows full history with details.",
+  },
+  "Visites": { fr: "Visites", en: "Visits" },
+  "Ajouter une cueillette": { fr: "Ajouter une cueillette", en: "Add a harvest" },
+  "Aucune visite enregistrée.": { fr: "Aucune visite enregistrée.", en: "No visit recorded." },
+  "Note:": { fr: "Note:", en: "Rating:" },
+  "Galerie": { fr: "Galerie", en: "Gallery" },
+  "Aucune photo.": { fr: "Aucune photo.", en: "No photo." },
+  "photos": { fr: "photos", en: "photos" },
+  "Mon nouveau coin": { fr: "Mon nouveau coin", en: "My new spot" },
+  "Création": { fr: "Création", en: "Creation" },
+  "Nom du coin": { fr: "Nom du coin", en: "Spot name" },
+  "Localisation (coordonnées ou lieu)": {
+    fr: "Localisation (coordonnées ou lieu)",
+    en: "Location (coordinates or place)",
+  },
+  "forêt brumeuse": { fr: "forêt brumeuse", en: "misty forest" },
+  "Trouvez vos coins à champignons comestibles, même sans réseau.": {
+    fr: "Trouvez vos coins à champignons comestibles, même sans réseau.",
+    en: "Find your edible mushroom spots, even offline.",
+  },
+  "Voir la carte": { fr: "Voir la carte", en: "See map" },
+  "Les champignons": { fr: "Les champignons", en: "Mushrooms" },
+  "Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.": {
+    fr: "Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.",
+    en: "Mini offline pack included: topo map (50 km) + sheets Porcini, Chanterelle, Morel.",
+  },
+  "Sélectionnez un champignon…": { fr: "Sélectionnez un champignon…", en: "Select a mushroom…" },
+  "comestible": { fr: "comestible", en: "edible" },
+  "toxique": { fr: "toxique", en: "toxic" },
+  "Saison": { fr: "Saison", en: "Season" },
+  "Habitat": { fr: "Habitat", en: "Habitat" },
+  "Météo idéale": { fr: "Météo idéale", en: "Ideal weather" },
+  "Description rapide": { fr: "Description rapide", en: "Quick description" },
+  "Valeur culinaire + conseils": { fr: "Valeur culinaire + conseils", en: "Culinary value + tips" },
+  "Exemples de plats": { fr: "Exemples de plats", en: "Dish examples" },
+  "Confusions possibles": { fr: "Confusions possibles", en: "Possible confusions" },
+  "Conseils cueillette": { fr: "Conseils cueillette", en: "Picking tips" },
+  "Voir zones optimales": { fr: "Voir zones optimales", en: "See optimal zones" },
+  "Fiche complète consultable hors‑ligne.": {
+    fr: "Fiche complète consultable hors‑ligne.",
+    en: "Full sheet available offline.",
+  },
+  "Rechercher une zone…": { fr: "Rechercher une zone…", en: "Search a zone…" },
+  "Vue actuelle": { fr: "Vue actuelle", en: "Current view" },
+  "Taille estimée": { fr: "Taille estimée", en: "Estimated size" },
+  "Espace disponible": { fr: "Espace disponible", en: "Available space" },
+  "Temps estimé": { fr: "Temps estimé", en: "Estimated time" },
+  "Inclure relief / altitudes": { fr: "Inclure relief / altitudes", en: "Include relief / elevation" },
+  "Inclure prévisions météo locales": {
+    fr: "Inclure prévisions météo locales",
+    en: "Include local weather forecast",
+  },
+  "Télécharger": { fr: "Télécharger", en: "Download" },
+  "États possibles": { fr: "États possibles", en: "Possible states" },
+  "Succès → « Carte téléchargée et prête hors‑ligne »": {
+    fr: "Succès → « Carte téléchargée et prête hors‑ligne »",
+    en: "Success → 'Map downloaded and ready offline'",
+  },
+  "Échec réseau → « Téléchargement interrompu – reprendra automatiquement »": {
+    fr: "Échec réseau → « Téléchargement interrompu – reprendra automatiquement »",
+    en: "Network failure → 'Download interrupted – will resume automatically'",
+  },
+  "Manque d'espace → « Espace insuffisant. Libérez n Mo »": {
+    fr: "Manque d'espace → « Espace insuffisant. Libérez n Mo »",
+    en: "Not enough space → 'Not enough space. Free n MB'",
+  },
+  "Les cartes incluent les données des 3 champignons par défaut.": {
+    fr: "Les cartes incluent les données des 3 champignons par défaut.",
+    en: "Maps include data for the 3 default mushrooms.",
+  },
+  "Instructions étape par étape (démo) :": {
+    fr: "Instructions étape par étape (démo) :",
+    en: "Step-by-step instructions (demo):",
+  },
+  "Rejoindre parking": { fr: "Rejoindre parking", en: "Reach parking" },
+  "Sentier balisé": { fr: "Sentier balisé", en: "Marked trail" },
+  "Boussole sur 250 m": { fr: "Boussole sur 250 m", en: "Compass for 250 m" },
+  "Marquer véhicule": { fr: "Marquer véhicule", en: "Mark vehicle" },
+  "Retour carte": { fr: "Retour carte", en: "Back to map" },
+  "Navigation piéton/boussole disponible hors‑ligne si la zone est téléchargée.": {
+    fr: "Navigation piéton/boussole disponible hors‑ligne si la zone est téléchargée.",
+    en: "Pedestrian/compass navigation available offline if the zone is downloaded.",
+  },
+  "J": { fr: "J", en: "D" },
+  "Optimum prévu": { fr: "Optimum prévu", en: "Optimum forecast" },
+  "Nouvelle zone proche": { fr: "Nouvelle zone proche", en: "New nearby zone" },
+  "Cartes hors‑ligne": { fr: "Cartes hors‑ligne", en: "Offline maps" },
+  "Pack initial (50 km)": { fr: "Pack initial (50 km)", en: "Initial pack (50 km)" },
+  "Topo + Cèpe/Girolle/Morille": {
+    fr: "Topo + Cèpe/Girolle/Morille",
+    en: "Topo + Porcini/Chanterelle/Morel",
+  },
+  "Télécharger une zone": { fr: "Télécharger une zone", en: "Download a zone" },
+  "Alertes": { fr: "Alertes", en: "Alerts" },
+  "Unités": { fr: "Unités", en: "Units" },
+  "métriques": { fr: "métriques", en: "metric" },
+  "impériales": { fr: "impériales", en: "imperial" },
+  "Thème": { fr: "Thème", en: "Theme" },
+  "auto": { fr: "auto", en: "auto" },
+  "clair": { fr: "clair", en: "light" },
+  "sombre": { fr: "sombre", en: "dark" },
+  "Langue": { fr: "Langue", en: "Language" },
+  "français": { fr: "français", en: "French" },
+  "anglais": { fr: "anglais", en: "English" },
+  "« À propos » • « Conseils de cueillette »": {
+    fr: "« À propos » • « Conseils de cueillette »",
+    en: '"About" • "Picking tips"',
+  },
+  "Rechercher un champignon…": { fr: "Rechercher un champignon…", en: "Search a mushroom…" },
+  "Toutes saisons": { fr: "Toutes saisons", en: "All seasons" },
+  "Printemps": { fr: "Printemps", en: "Spring" },
+  "Été": { fr: "Été", en: "Summer" },
+  "Automne": { fr: "Automne", en: "Autumn" },
+  "Toute valeur": { fr: "Toute valeur", en: "Any value" },
+  "Excellente": { fr: "Excellente", en: "Excellent" },
+  "Bonne": { fr: "Bonne", en: "Good" },
+  "Moyenne": { fr: "Moyenne", en: "Average" },
+  "Saison :": { fr: "Saison :", en: "Season:" },
+  "Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.": {
+    fr: "Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.",
+    en: "Offline: Porcini, Chanterelle and Morel appear by default.",
+  },
+  "⬈ amélioration": { fr: "⬈ amélioration", en: "⬈ improving" },
+  "⬊ en baisse": { fr: "⬊ en baisse", en: "⬊ decreasing" },
+  "→ stable": { fr: "→ stable", en: "→ stable" },
+};
+
+import { useAppContext } from "./context/AppContext";
+
+export function useT() {
+  const { state } = useAppContext();
+  const lang = state.prefs.lang;
+  const t = (key: string, vars?: Record<string, any>) => {
+    let str = TRANSLATIONS[key]?.[lang] ?? key;
+    if (vars) {
+      Object.keys(vars).forEach((k) => {
+        str = str.replace(`{${k}}`, String(vars[k]));
+      });
+    }
+    return str;
+  };
+  return { t, lang };
+}

--- a/src/scenes/DownloadScene.tsx
+++ b/src/scenes/DownloadScene.tsx
@@ -8,8 +8,10 @@ import { Switch } from "@/components/ui/switch";
 import { Progress } from "@/components/ui/progress";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { Row } from "../components/Row";
+import { useT } from "../i18n";
 
 export default function DownloadScene({ packSize, setPackSize, deviceFree, setDeviceFree, includeRelief, setIncludeRelief, includeWeather, setIncludeWeather, downloading, dlProgress, onStart, onCancel, onBack }: { packSize: number; setPackSize: (n: number) => void; deviceFree: number; setDeviceFree: (n: number) => void; includeRelief: boolean; setIncludeRelief: (v: boolean) => void; includeWeather: boolean; setIncludeWeather: (v: boolean) => void; downloading: boolean; dlProgress: number; onStart: () => void; onCancel: () => void; onBack: () => void }) {
+  const { t } = useT();
   useEffect(() => {
     const base = 120;
     const size = base + (includeRelief ? 30 : 0) + (includeWeather ? 30 : 0);
@@ -20,36 +22,46 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
       <div className="flex items-center gap-2 mb-3">
         <div className="relative flex-1">
-          <Input placeholder="Rechercher une zone…" className={`pl-9 bg-neutral-900 border-neutral-800 ${T_PRIMARY}`} />
+          <Input
+            placeholder={t("Rechercher une zone…")}
+            className={`pl-9 bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+          />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
         </div>
-        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label="Retour">
+        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />
         </Button>
       </div>
       <div className="relative h-[50vh] rounded-2xl border border-neutral-800 overflow-hidden bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)]">
         <div className="absolute inset-6 border-2 border-red-600 rounded-xl" />
-        <div className={`absolute top-3 left-3 bg-neutral-900/80 rounded-xl px-3 py-1 text-sm ${T_PRIMARY}`}>Vue actuelle</div>
+        <div className={`absolute top-3 left-3 bg-neutral-900/80 rounded-xl px-3 py-1 text-sm ${T_PRIMARY}`}>
+          {t("Vue actuelle")}
+        </div>
       </div>
 
       <div className="mt-3 grid md:grid-cols-2 gap-3">
         <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
           <CardContent className="pt-4 space-y-2">
-            <Row label="Taille estimée" value={`${packSize} Mo`} />
-            <Row label="Espace disponible" value={`${deviceFree} Mo`} />
-            <Row label="Temps estimé" value="~ 45 s" />
+            <Row label={t("Taille estimée")} value={`${packSize} Mo`} />
+            <Row label={t("Espace disponible")} value={`${deviceFree} Mo`} />
+            <Row label={t("Temps estimé")} value="~ 45 s" />
             <div className="flex items-center justify-between">
-              <div className={`text-sm ${T_PRIMARY}`}>Inclure relief / altitudes</div>
+              <div className={`text-sm ${T_PRIMARY}`}>{t("Inclure relief / altitudes")}</div>
               <Switch checked={includeRelief} onCheckedChange={setIncludeRelief} />
             </div>
             <div className="flex items-center justify-between">
-              <div className={`text-sm ${T_PRIMARY}`}>Inclure prévisions météo locales</div>
+              <div className={`text-sm ${T_PRIMARY}`}>{t("Inclure prévisions météo locales")}</div>
               <Switch checked={includeWeather} onCheckedChange={setIncludeWeather} />
             </div>
             {!downloading ? (
               <div className="flex gap-2">
-                <Button onClick={onStart} className={`${BTN} flex-1`}><Download className="w-4 h-4 mr-2" />Télécharger</Button>
-                <Button variant="ghost" onClick={onCancel} className={`flex-1 rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>Annuler</Button>
+                <Button onClick={onStart} className={`${BTN} flex-1`}>
+                  <Download className="w-4 h-4 mr-2" />
+                  {t("Télécharger")}
+                </Button>
+                <Button variant="ghost" onClick={onCancel} className={`flex-1 rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>
+                  {t("Annuler")}
+                </Button>
               </div>
             ) : (
               <div className="space-y-2">
@@ -61,12 +73,16 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
         </Card>
 
         <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
-          <CardHeader><CardTitle className={T_PRIMARY}>États possibles</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle className={T_PRIMARY}>{t("États possibles")}</CardTitle>
+          </CardHeader>
           <CardContent className={`text-sm ${T_MUTED} space-y-1`}>
-            <div>• Succès → « Carte téléchargée et prête hors‑ligne »</div>
-            <div>• Échec réseau → « Téléchargement interrompu – reprendra automatiquement »</div>
-            <div>• Manque d'espace → « Espace insuffisant. Libérez n Mo »</div>
-            <div className={`text-xs ${T_SUBTLE}`}>Les cartes incluent les données des 3 champignons par défaut.</div>
+            <div>• {t("Succès → « Carte téléchargée et prête hors‑ligne »")}</div>
+            <div>• {t("Échec réseau → « Téléchargement interrompu – reprendra automatiquement »")}</div>
+            <div>• {t("Manque d'espace → « Espace insuffisant. Libérez n Mo »")}</div>
+            <div className={`text-xs ${T_SUBTLE}`}>
+              {t("Les cartes incluent les données des 3 champignons par défaut.")}
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -4,29 +4,51 @@ import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MushroomIcon } from "../components/MushroomIcon";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
+import { useT } from "../i18n";
 
 export default function LandingScene({ onSeeMap, onMySpots, onOpenSettings, onOpenPicker }: { onSeeMap: () => void; onMySpots: () => void; onOpenSettings: () => void; onOpenPicker: () => void }) {
+  const { t } = useT();
   return (
     <motion.section initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="relative min-h-[calc(100vh-0px)]">
       <div className="absolute top-3 right-3 z-20">
-        <Button variant="ghost" size="icon" onClick={onOpenSettings} className={BTN_GHOST_ICON} aria-label="Réglages">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onOpenSettings}
+          className={BTN_GHOST_ICON}
+          aria-label={t("Réglages")}
+        >
           <Menu className="w-7 h-7" />
         </Button>
       </div>
 
-      <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?q=80&w=1920&auto=format&fit=crop" alt="forêt brumeuse" className="absolute inset-0 w-full h-full object-cover" />
+      <img
+        src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?q=80&w=1920&auto=format&fit=crop"
+        alt={t("forêt brumeuse")}
+        className="absolute inset-0 w-full h-full object-cover"
+      />
       <div className="absolute inset-0 bg-black/60" />
       <div className="relative z-10 max-w-3xl mx-auto px-6 py-20 text-center">
         <div className="mx-auto mb-6 w-20 h-20 rounded-2xl bg-neutral-800/60 border border-neutral-700 grid place-items-center shadow-xl">
           <MushroomIcon className={T_PRIMARY} />
         </div>
-        <h1 className={`text-3xl font-semibold ${T_PRIMARY}`}>Trouvez vos coins à champignons comestibles, même sans réseau.</h1>
+        <h1 className={`text-3xl font-semibold ${T_PRIMARY}`}>
+          {t("Trouvez vos coins à champignons comestibles, même sans réseau.")}
+        </h1>
         <div className="mt-6 flex items-center justify-center gap-3">
-          <Button onClick={onSeeMap} className={BTN}>Voir la carte</Button>
-          <Button onClick={onMySpots} className={BTN}>Mes coins</Button>
-          <Button onClick={onOpenPicker} className={BTN}>Les champignons</Button>
+          <Button onClick={onSeeMap} className={BTN}>
+            {t("Voir la carte")}
+          </Button>
+          <Button onClick={onMySpots} className={BTN}>
+            {t("Mes coins")}
+          </Button>
+          <Button onClick={onOpenPicker} className={BTN}>
+            {t("Les champignons")}
+          </Button>
         </div>
-        <p className={`mt-8 text-sm ${T_MUTED}`}>Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.</p>
+        <p className={`mt-8 text-sm ${T_MUTED}`}>
+          {t("Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.")}
+        </p>
       </div>
     </motion.section>
   );

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -11,6 +11,7 @@ import { classNames } from "../utils";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import mapboxgl from "mapbox-gl";
 import { useAppContext } from "../context/AppContext";
+import { useT } from "../i18n";
 
 export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow, onBack }: { onZone: (z: any) => void; onOpenShroom: (id: string) => void; gpsFollow: boolean; setGpsFollow: (v: (p: boolean) => boolean | boolean) => void; onBack: () => void }) {
   const [selectedSpecies, setSelectedSpecies] = useState<string[]>([]);
@@ -18,6 +19,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
   const mapContainer = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const { state } = useAppContext();
+  const { t } = useT();
 
   useEffect(() => {
     if (mapRef.current) return;
@@ -50,23 +52,40 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
       <div className="flex items-center gap-2 mb-3">
-        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label="Retour">
+        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />
         </Button>
         <div className="relative flex-1">
-          <Input placeholder="Rechercher un lieu…" className={`pl-9 bg-neutral-900 border-neutral-800 ${T_PRIMARY}`} />
+          <Input
+            placeholder={t("Rechercher un lieu…")}
+            className={`pl-9 bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+          />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
         </div>
-        <Button onClick={() => setGpsFollow(v => !v)} className={BTN}><LocateFixed className="w-4 h-4 mr-2" />GPS</Button>
+        <Button onClick={() => setGpsFollow(v => !v)} className={BTN}>
+          <LocateFixed className="w-4 h-4 mr-2" />
+          {t("GPS")}
+        </Button>
       </div>
 
       <div className="relative h-[60vh] rounded-2xl border border-neutral-800 overflow-hidden">
         <div ref={mapContainer} className="absolute inset-0 w-full h-full" />
 
         <div className="absolute top-3 left-3 flex flex-col gap-2">
-          <Button variant="ghost" size="icon" onClick={() => setGpsFollow(true)} className={BTN_GHOST_ICON} aria-label="Ma position">📍</Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setGpsFollow(true)}
+            className={BTN_GHOST_ICON}
+            aria-label={t("Ma position")}
+          >
+            📍
+          </Button>
           <div className="bg-neutral-900/80 backdrop-blur rounded-xl p-2 border border-neutral-800 flex items-center gap-2">
-            <span className={`text-xs ${T_PRIMARY}`}>Légende J{state.day >= 0 ? "+" : ""}{state.day}</span>
+            <span className={`text-xs ${T_PRIMARY}`}>
+              {t("Légende")} J{state.day >= 0 ? "+" : ""}
+              {state.day}
+            </span>
             {LEGEND.map((l, i) => (
               <div key={i} className="flex items-center gap-1">
                 <div className={classNames("w-3 h-3 rounded", l.color)} />
@@ -83,7 +102,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
                 <div className={`font-medium ${T_PRIMARY}`}>{z.name}</div>
                 <Badge variant={z.score > 85 ? "default" : "secondary"}>{z.score}%</Badge>
               </div>
-              <div className={`text-xs ${T_MUTED}`}>{z.trend}</div>
+              <div className={`text-xs ${T_MUTED}`}>{t(z.trend)}</div>
               <div className="mt-1 flex gap-1">
                 {Object.entries(z.species).map(([id, sc]) => (
                   <span key={id} onClick={(e) => { e.stopPropagation(); onOpenShroom(id); }} className={`text-[10px] bg-neutral-800 border border-neutral-700 px-2 py-1 rounded-full hover:bg-neutral-700 ${T_PRIMARY} cursor-pointer`}>{MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0]} {sc}%</span>
@@ -107,7 +126,9 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
         })}
       </div>
 
-      <p className={`text-xs mt-2 ${T_SUBTLE}`}>Hors ligne : affichage des zones optimales Cèpe, Girolle, Morille.</p>
+      <p className={`text-xs mt-2 ${T_SUBTLE}`}>
+        {t("Hors ligne : affichage des zones optimales Cèpe, Girolle, Morille.")}
+      </p>
     </motion.section>
   );
 }

--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -5,12 +5,20 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { InfoBlock } from "../components/InfoBlock";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_SUBTLE } from "../styles/tokens";
+import { useT } from "../i18n";
 
 export default function MushroomScene({ item, onSeeZones, onBack }: { item: any; onSeeZones: () => void; onBack: () => void }) {
-  if (!item) return <div className={`p-6 ${T_PRIMARY}`}>Sélectionnez un champignon…</div>;
+  const { t } = useT();
+  if (!item) return <div className={`p-6 ${T_PRIMARY}`}>{t("Sélectionnez un champignon…")}</div>;
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
-      <Button variant="ghost" size="icon" onClick={onBack} className={`${BTN_GHOST_ICON} mb-3`} aria-label="Retour">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onBack}
+        className={`${BTN_GHOST_ICON} mb-3`}
+        aria-label={t("Retour")}
+      >
         <ChevronLeft className="w-5 h-5" />
       </Button>
       <div className="rounded-2xl overflow-hidden border border-neutral-800">
@@ -20,26 +28,41 @@ export default function MushroomScene({ item, onSeeZones, onBack }: { item: any;
       <div className="mt-3 flex items-center gap-2">
         <h2 className={`text-xl font-semibold ${T_PRIMARY}`}>{item.name}</h2>
         <Badge variant="secondary">{item.latin}</Badge>
-        {item.edible ? <Badge className="bg-emerald-700">🍴 comestible</Badge> : <Badge className="bg-red-700">☠️ toxique</Badge>}
+        {item.edible ? (
+          <Badge className="bg-emerald-700">🍴 {t("comestible")}</Badge>
+        ) : (
+          <Badge className="bg-red-700">☠️ {t("toxique")}</Badge>
+        )}
       </div>
 
       <div className="grid md:grid-cols-2 gap-3 mt-3">
-        <InfoBlock icon={<Calendar className="w-4 h-4" />} title="Saison" text={item.season} />
-        <InfoBlock icon={<Trees className="w-4 h-4" />} title="Habitat" text={item.habitat} />
-        <InfoBlock icon={<CloudSun className="w-4 h-4" />} title="Météo idéale" text={item.weatherIdeal} />
-        <InfoBlock icon={<Info className="w-4 h-4" />} title="Description rapide" text={item.description} />
-        <InfoBlock icon={<ChefHat className="w-4 h-4" />} title="Valeur culinaire + conseils" text={`${item.culinary}. ${item.cookingTips}`} />
-        <InfoBlock icon={<Sandwich className="w-4 h-4" />} title="Exemples de plats" text={item.dishes.join(" • ")} />
-        <InfoBlock icon={<TriangleAlert className="w-4 h-4" />} title="Confusions possibles" text={item.confusions.join(" • ")} />
-        <InfoBlock icon={<Compass className="w-4 h-4" />} title="Conseils cueillette" text={item.picking} />
+        <InfoBlock icon={<Calendar className="w-4 h-4" />} title={t("Saison")} text={item.season} />
+        <InfoBlock icon={<Trees className="w-4 h-4" />} title={t("Habitat")} text={item.habitat} />
+        <InfoBlock icon={<CloudSun className="w-4 h-4" />} title={t("Météo idéale")} text={item.weatherIdeal} />
+        <InfoBlock icon={<Info className="w-4 h-4" />} title={t("Description rapide")} text={item.description} />
+        <InfoBlock
+          icon={<ChefHat className="w-4 h-4" />}
+          title={t("Valeur culinaire + conseils")}
+          text={`${item.culinary}. ${item.cookingTips}`}
+        />
+        <InfoBlock icon={<Sandwich className="w-4 h-4" />} title={t("Exemples de plats")} text={item.dishes.join(" • ")} />
+        <InfoBlock
+          icon={<TriangleAlert className="w-4 h-4" />}
+          title={t("Confusions possibles")}
+          text={item.confusions.join(" • ")}
+        />
+        <InfoBlock icon={<Compass className="w-4 h-4" />} title={t("Conseils cueillette")} text={item.picking} />
       </div>
 
       {item.edible && (
         <div className="mt-4">
-          <Button onClick={onSeeZones} className={BTN}><MapPin className="w-4 h-4 mr-2" />Voir zones optimales</Button>
+          <Button onClick={onSeeZones} className={BTN}>
+            <MapPin className="w-4 h-4 mr-2" />
+            {t("Voir zones optimales")}
+          </Button>
         </div>
       )}
-      <p className={`text-xs mt-2 ${T_SUBTLE}`}>Fiche complète consultable hors‑ligne.</p>
+      <p className={`text-xs mt-2 ${T_SUBTLE}`}>{t("Fiche complète consultable hors‑ligne.")}</p>
     </motion.section>
   );
 }

--- a/src/scenes/PickerScene.tsx
+++ b/src/scenes/PickerScene.tsx
@@ -4,28 +4,35 @@ import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { useT } from "../i18n";
 
 export default function PickerScene({ items, search, setSearch, onPick, onBack }: { items: any[]; search: string; setSearch: (v: string) => void; onPick: (m: any) => void; onBack: () => void }) {
   const [seasonFilter, setSeasonFilter] = useState("toutes");
   const [valueFilter, setValueFilter] = useState("toutes");
+  const { t } = useT();
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
       <div className="grid md:grid-cols-4 gap-2 mb-3 items-center">
-        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label="Retour">
+        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />
         </Button>
-        <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Rechercher un champignon…" className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`} />
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t("Rechercher un champignon…")}
+          className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+        />
         <select value={seasonFilter} onChange={(e) => setSeasonFilter(e.target.value)} className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
-          <option value="toutes">Toutes saisons</option>
-          <option>Printemps</option>
-          <option>Été</option>
-          <option>Automne</option>
+          <option value="toutes">{t("Toutes saisons")}</option>
+          <option>{t("Printemps")}</option>
+          <option>{t("Été")}</option>
+          <option>{t("Automne")}</option>
         </select>
         <select value={valueFilter} onChange={(e) => setValueFilter(e.target.value)} className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
-          <option value="toutes">Toute valeur</option>
-          <option>Excellente</option>
-          <option>Bonne</option>
-          <option>Moyenne</option>
+          <option value="toutes">{t("Toute valeur")}</option>
+          <option>{t("Excellente")}</option>
+          <option>{t("Bonne")}</option>
+          <option>{t("Moyenne")}</option>
         </select>
       </div>
 
@@ -35,12 +42,14 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
             <img src={m.photo} className="w-full h-40 object-cover" />
             <div className="p-3">
               <div className={`font-medium ${T_PRIMARY}`}>{m.name}</div>
-              <div className={`text-xs ${T_MUTED}`}>Saison : {m.season}</div>
+              <div className={`text-xs ${T_MUTED}`}>{t("Saison :")} {m.season}</div>
             </div>
           </button>
         ))}
       </div>
-      <p className={`text-xs mt-2 ${T_SUBTLE}`}>Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.</p>
+      <p className={`text-xs mt-2 ${T_SUBTLE}`}>
+        {t("Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.")}
+      </p>
     </motion.section>
   );
 }

--- a/src/scenes/RouteScene.tsx
+++ b/src/scenes/RouteScene.tsx
@@ -3,21 +3,28 @@ import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BTN, BTN_GHOST_ICON, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { useT } from "../i18n";
 
 export default function RouteScene({ onBackToMap, onBack }: { onBackToMap: () => void; onBack: () => void }) {
+  const { t } = useT();
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
-      <Button variant="ghost" size="icon" onClick={onBack} className={`${BTN_GHOST_ICON} mb-3`} aria-label="Retour">
+      <Button variant="ghost" size="icon" onClick={onBack} className={`${BTN_GHOST_ICON} mb-3`} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
       <div className="relative h-[60vh] rounded-2xl border border-neutral-800 overflow-hidden bg-neutral-900 grid">
-        <div className={`p-3 text-sm ${T_MUTED}`}>Instructions étape par étape (démo) : <br/>🚗 Rejoindre parking → 🚶 Sentier balisé → 🧭 Boussole sur 250 m</div>
+        <div className={`p-3 text-sm ${T_MUTED}`}>
+          {t("Instructions étape par étape (démo) :")}
+          <br />🚗 {t("Rejoindre parking")} → 🚶 {t("Sentier balisé")} → 🧭 {t("Boussole sur 250 m")}
+        </div>
         <div className="absolute top-3 right-3 flex gap-2">
-          <Button className={BTN}>Marquer véhicule</Button>
-          <Button onClick={onBackToMap} className={BTN}>Retour carte</Button>
+          <Button className={BTN}>{t("Marquer véhicule")}</Button>
+          <Button onClick={onBackToMap} className={BTN}>{t("Retour carte")}</Button>
         </div>
       </div>
-      <p className={`text-xs mt-2 ${T_SUBTLE}`}>Navigation piéton/boussole disponible hors‑ligne si la zone est téléchargée.</p>
+      <p className={`text-xs mt-2 ${T_SUBTLE}`}>
+        {t("Navigation piéton/boussole disponible hors‑ligne si la zone est téléchargée.")}
+      </p>
     </motion.section>
   );
 }

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -7,46 +7,97 @@ import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
 import { ToggleRow } from "../components/ToggleRow";
 import { SelectRow } from "../components/SelectRow";
 import { useAppContext } from "../context/AppContext";
+import { useT } from "../i18n";
 
 export default function SettingsScene({ onOpenPacks, onBack }: { onOpenPacks: () => void; onBack: () => void }) {
   const { state, dispatch } = useAppContext();
   const { alerts, prefs } = state;
+  const { t } = useT();
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3 space-y-3">
-      <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label="Retour">
+      <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
       <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
-        <CardHeader><CardTitle className={T_PRIMARY}>Cartes hors‑ligne</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle className={T_PRIMARY}>{t("Cartes hors‑ligne")}</CardTitle>
+        </CardHeader>
         <CardContent>
           <div className="flex items-center justify-between">
             <div>
-              <div className={`font-medium ${T_PRIMARY}`}>Pack initial (50 km)</div>
-              <div className={`text-xs ${T_MUTED}`}>Topo + Cèpe/Girolle/Morille</div>
+              <div className={`font-medium ${T_PRIMARY}`}>{t("Pack initial (50 km)")}</div>
+              <div className={`text-xs ${T_MUTED}`}>{t("Topo + Cèpe/Girolle/Morille")}</div>
             </div>
-            <Button onClick={onOpenPacks} className={BTN}><Download className="w-4 h-4 mr-2" />Télécharger une zone</Button>
+            <Button onClick={onOpenPacks} className={BTN}>
+              <Download className="w-4 h-4 mr-2" />
+              {t("Télécharger une zone")}
+            </Button>
           </div>
         </CardContent>
       </Card>
 
       <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
-        <CardHeader><CardTitle className={T_PRIMARY}>Alertes</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle className={T_PRIMARY}>{t("Alertes")}</CardTitle>
+        </CardHeader>
         <CardContent className="space-y-2">
-          <ToggleRow label="Optimum prévu" checked={alerts.optimum} onChange={(v) => dispatch({ type: "setAlerts", alerts: { optimum: v } })} />
-          <ToggleRow label="Nouvelle zone proche" checked={alerts.newZone} onChange={(v) => dispatch({ type: "setAlerts", alerts: { newZone: v } })} />
+          <ToggleRow
+            label={t("Optimum prévu")}
+            checked={alerts.optimum}
+            onChange={(v) => dispatch({ type: "setAlerts", alerts: { optimum: v } })}
+          />
+          <ToggleRow
+            label={t("Nouvelle zone proche")}
+            checked={alerts.newZone}
+            onChange={(v) => dispatch({ type: "setAlerts", alerts: { newZone: v } })}
+          />
         </CardContent>
       </Card>
 
       <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
-        <CardHeader><CardTitle className={T_PRIMARY}>Préférences</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle className={T_PRIMARY}>{t("Préférences")}</CardTitle>
+        </CardHeader>
         <CardContent className="space-y-2">
-          <SelectRow label="Unités" value={prefs.units} options={["métriques", "impériales"]} onChange={(v) => dispatch({ type: "setPrefs", prefs: { units: v } })} />
-          <SelectRow label="Thème" value={prefs.theme} options={["auto", "clair", "sombre"]} onChange={(v) => dispatch({ type: "setPrefs", prefs: { theme: v } })} />
-          <ToggleRow label="GPS" checked={prefs.gps} onChange={(v) => dispatch({ type: "setPrefs", prefs: { gps: v } })} />
+          <SelectRow
+            label={t("Unités")}
+            value={prefs.units}
+            options={[
+              { value: "métriques", label: t("métriques") },
+              { value: "impériales", label: t("impériales") },
+            ]}
+            onChange={(v) => dispatch({ type: "setPrefs", prefs: { units: v } })}
+          />
+          <SelectRow
+            label={t("Thème")}
+            value={prefs.theme}
+            options={[
+              { value: "auto", label: t("auto") },
+              { value: "clair", label: t("clair") },
+              { value: "sombre", label: t("sombre") },
+            ]}
+            onChange={(v) => dispatch({ type: "setPrefs", prefs: { theme: v } })}
+          />
+          <ToggleRow
+            label={t("GPS")}
+            checked={prefs.gps}
+            onChange={(v) => dispatch({ type: "setPrefs", prefs: { gps: v } })}
+          />
+          <SelectRow
+            label={t("Langue")}
+            value={prefs.lang}
+            options={[
+              { value: "fr", label: t("français") },
+              { value: "en", label: t("anglais") },
+            ]}
+            onChange={(v) => dispatch({ type: "setPrefs", prefs: { lang: v } })}
+          />
         </CardContent>
       </Card>
 
-      <div className={`text-sm ${T_MUTED}`}>« À propos » • « Conseils de cueillette »</div>
+      <div className={`text-sm ${T_MUTED}`}>
+        {t("« À propos » • « Conseils de cueillette »")}
+      </div>
     </motion.section>
   );
 }

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -8,6 +8,7 @@ import { CreateSpotModal } from "../components/CreateSpotModal";
 import { EditSpotModal } from "../components/EditSpotModal";
 import { SpotDetailsModal } from "../components/SpotDetailsModal";
 import { useAppContext } from "../context/AppContext";
+import { useT } from "../i18n";
 
 export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; onBack: () => void }) {
   const { state, dispatch } = useAppContext();
@@ -15,30 +16,46 @@ export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; o
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<any>(null);
   const [details, setDetails] = useState<any>(null);
+  const { t } = useT();
 
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3 space-y-3">
       <div className="relative h-10">
-        <Button variant="ghost" size="icon" onClick={onBack} className={`absolute left-0 ${BTN_GHOST_ICON}`} aria-label="Retour">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          className={`absolute left-0 ${BTN_GHOST_ICON}`}
+          aria-label={t("Retour")}
+        >
           <ChevronLeft className="w-5 h-5" />
         </Button>
-        <h2 className={`absolute inset-0 grid place-items-center text-lg font-semibold ${T_PRIMARY}`}>Mes coins</h2>
+        <h2 className={`absolute inset-0 grid place-items-center text-lg font-semibold ${T_PRIMARY}`}>
+          {t("Mes coins")}
+        </h2>
       </div>
 
       {!createOpen && (
         <div className="flex justify-end">
-          <Button onClick={() => setCreateOpen(true)} className={BTN}><Plus className="w-4 h-4 mr-2" />Nouveau coin</Button>
+          <Button onClick={() => setCreateOpen(true)} className={BTN}>
+            <Plus className="w-4 h-4 mr-2" />
+            {t("Nouveau coin")}
+          </Button>
         </div>
       )}
 
       <div className="grid md:grid-cols-2 gap-3">
-        {spots.length === 0 && <div className={T_PRIMARY}>Aucun coin enregistré.</div>}
+        {spots.length === 0 && <div className={T_PRIMARY}>{t("Aucun coin enregistré.")}</div>}
         {spots.map(s => (
           <Card key={s.id} className="bg-neutral-900 border-neutral-800 rounded-2xl overflow-hidden relative">
             <button onClick={() => setDetails(s)} className="block text-left">
               <img src={s.cover || s.photo} className="w-full h-40 object-cover" />
             </button>
-            <button onClick={() => setEditing(s)} className="absolute top-2 right-2 bg-neutral-900/80 hover:bg-neutral-800/80 border border-neutral-700 rounded-full p-2" aria-label="modifier">
+            <button
+              onClick={() => setEditing(s)}
+              className="absolute top-2 right-2 bg-neutral-900/80 hover:bg-neutral-800/80 border border-neutral-700 rounded-full p-2"
+              aria-label={t("modifier")}
+            >
               <Pencil className="w-4 h-4 text-neutral-200" />
             </button>
             <CardContent className="p-4">
@@ -46,16 +63,23 @@ export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; o
                 <div className={`font-medium ${T_PRIMARY}`}>{s.name}</div>
                 <div className="flex items-center gap-1 text-amber-400">{"★".repeat(s.rating || 0)}</div>
               </div>
-              <div className={`text-xs ${T_MUTED}`}>Espèces : {(s.species || []).join(", ")}</div>
-              <div className={`text-xs ${T_MUTED}`}>Dernière visite : {s.last || "–"}</div>
+              <div className={`text-xs ${T_MUTED}`}>
+                {t("Espèces :")} {(s.species || []).join(", ")}
+              </div>
+              <div className={`text-xs ${T_MUTED}`}>
+                {t("Dernière visite :")} {s.last || "–"}
+              </div>
               <div className="mt-3 flex gap-2">
-                <Button onClick={onRoute} className={BTN}><Route className="w-4 h-4 mr-2" />Itinéraire</Button>
+                <Button onClick={onRoute} className={BTN}>
+                  <Route className="w-4 h-4 mr-2" />
+                  {t("Itinéraire")}
+                </Button>
               </div>
             </CardContent>
           </Card>
         ))}
       </div>
-      <p className={`text-xs ${T_SUBTLE}`}>Données stockées localement. Accès hors‑ligne.</p>
+      <p className={`text-xs ${T_SUBTLE}`}>{t("Données stockées localement. Accès hors‑ligne.")}</p>
 
       {createOpen && (
         <CreateSpotModal

--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -8,13 +8,22 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, ReferenceL
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { MUSHROOMS } from "../data/mushrooms";
 import { generateForecast } from "../utils";
+import { useT } from "../i18n";
 
 export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: { zone: any; onGo: () => void; onAdd: () => void; onOpenShroom: (id: string) => void; onBack: () => void }) {
+  const { t } = useT();
   const data = useMemo(() => generateForecast(), [zone?.id]);
-  if (!zone) return <div className={`p-6 ${T_PRIMARY}`}>Sélectionnez une zone…</div>;
+  if (!zone)
+    return <div className={`p-6 ${T_PRIMARY}`}>{t("Sélectionnez une zone…")}</div>;
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
-      <Button variant="ghost" size="icon" onClick={onBack} className={`${BTN_GHOST_ICON} mb-3`} aria-label="Retour">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onBack}
+        className={`${BTN_GHOST_ICON} mb-3`}
+        aria-label={t("Retour")}
+      >
         <ChevronLeft className="w-5 h-5" />
       </Button>
       <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
@@ -39,10 +48,10 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
               </LineChart>
             </ResponsiveContainer>
           </div>
-          <div className={`mt-2 text-xs ${T_SUBTLE}`}>Icônes météo (démo)</div>
+          <div className={`mt-2 text-xs ${T_SUBTLE}`}>{t("Icônes météo (démo)")}</div>
 
           <div className="mt-4">
-            <div className={`text-sm mb-2 ${T_PRIMARY}`}>Comestibles probables</div>
+            <div className={`text-sm mb-2 ${T_PRIMARY}`}>{t("Comestibles probables")}</div>
             <div className="flex flex-wrap gap-2">
               {Object.entries(zone.species).filter(([_, v]) => v > 0).map(([id, sc]) => {
                 const m = MUSHROOMS.find(m => m.id === id);
@@ -52,7 +61,7 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
                       <img src={m.photo} className="w-12 h-12 object-cover rounded-lg" />
                       <div>
                         <div className={`text-sm font-medium ${T_PRIMARY}`}>{m.name}</div>
-                        <div className={`text-xs ${T_MUTED}`}>Score {sc}%</div>
+                        <div className={`text-xs ${T_MUTED}`}>{t("Score {sc}%", { sc })}</div>
                       </div>
                     </div>
                   </button>
@@ -62,10 +71,18 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
           </div>
 
           <div className="mt-4 flex items-center gap-2">
-            <Button onClick={onGo} className={BTN}><Route className="w-4 h-4 mr-2" />Y aller</Button>
-            <Button onClick={onAdd} className={BTN}><Plus className="w-4 h-4 mr-2" />Ajouter à mes coins</Button>
+            <Button onClick={onGo} className={BTN}>
+              <Route className="w-4 h-4 mr-2" />
+              {t("Y aller")}
+            </Button>
+            <Button onClick={onAdd} className={BTN}>
+              <Plus className="w-4 h-4 mr-2" />
+              {t("Ajouter à mes coins")}
+            </Button>
           </div>
-          <p className={`text-xs mt-2 ${T_SUBTLE}`}>Prévisions locales hors‑ligne (7 jours) disponibles pour 3 champignons inclus.</p>
+          <p className={`text-xs mt-2 ${T_SUBTLE}`}>
+            {t("Prévisions locales hors‑ligne (7 jours) disponibles pour 3 champignons inclus.")}
+          </p>
         </CardContent>
       </Card>
     </motion.section>


### PR DESCRIPTION
## Summary
- add translation utility and dictionaries for English and French
- extend context and settings to store and switch language preference
- translate UI texts across scenes and components

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689900f2dba083299aa8ff0d573aec41