### PR TITLE
feat: add light and dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ function AppContent() {
   const [toast, setToast] = useState<{ type: "success" | "warn"; text: string } | null>(null);
   const [gpsFollow, setGpsFollow] = useState(false);
 
-  const { dispatch } = useAppContext();
+  const { state, dispatch } = useAppContext();
   const { t } = useT();
 
   const goToScene = useCallback((next: number) => {
@@ -77,13 +77,25 @@ function AppContent() {
     }
   }, [downloading, goToScene]);
 
+  useEffect(() => {
+    const theme = state.prefs.theme;
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const applyTheme = () => {
+      const isDark = theme === "sombre" || (theme === "auto" && media.matches);
+      document.documentElement.classList.toggle("dark", isDark);
+    };
+    applyTheme();
+    media.addEventListener("change", applyTheme);
+    return () => media.removeEventListener("change", applyTheme);
+  }, [state.prefs.theme]);
+
   const filteredMushrooms = useMemo(
     () => MUSHROOMS.filter((m) => m.name.toLowerCase().includes(search.toLowerCase())),
     [search]
   );
 
   return (
-    <div className="w-full min-h-screen bg-neutral-950">
+    <div className="w-full min-h-screen bg-neutral-50 dark:bg-neutral-950">
       {toast && (
         <div
           className={classNames(

--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -37,7 +37,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
 
   return (
     <div ref={overlayRef} onClick={handleOutside} className="fixed inset-0 z-50 bg-black/70 grid place-items-center p-3">
-      <div className="w-full max-w-2xl bg-neutral-900 border border-neutral-800 rounded-2xl p-4">
+      <div className="w-full max-w-2xl bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl p-4">
         <div className="flex items-center justify-between mb-2">
           <div className={`text-lg font-semibold ${T_PRIMARY}`}>{t("Nouveau coin")}</div>
           <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
@@ -48,20 +48,20 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder={t("Nom du coin")}
-            className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+            className={`bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
           />
           <Input
             value={location}
             onChange={(e) => setLocation(e.target.value)}
             placeholder={t("Localisation (coordonnées ou lieu)")}
-            className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+            className={`bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
           />
 
           <div>
             <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Champignons trouvés")}</div>
             <div className="flex flex-wrap gap-2 mb-2">
               {species.map((id) => (
-                <span key={id} className="inline-flex items-center gap-1 bg-neutral-800 border border-neutral-700 rounded-full px-2 py-1 text-xs">
+                <span key={id} className="inline-flex items-center gap-1 bg-neutral-200 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-full px-2 py-1 text-xs">
                   <span className={T_PRIMARY}>{MUSHROOMS.find((m) => m.id === id)?.name.split(" ")[0]}</span>
                   <button
                     onClick={() => setSpecies((list) => list.filter((x) => x !== id))}
@@ -73,7 +73,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
                 </span>
               ))}
             </div>
-            <select onChange={(e) => { const v = e.target.value; if (v) setSpecies((list) => list.includes(v) ? list : [...list, v]); }} value="" className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
+            <select onChange={(e) => { const v = e.target.value; if (v) setSpecies((list) => list.includes(v) ? list : [...list, v]); }} value="" className="bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm">
               <option value="" disabled>
                 {t("Ajouter un champignon…")}
               </option>
@@ -86,7 +86,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
           <div>
             <div className={`text-sm ${T_PRIMARY}`}>{t("Dernière visite")}</div>
             <div className="mt-1">
-              <input type="date" value={last} onChange={(e) => setLast(e.target.value)} className="w-full bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100" />
+              <input type="date" value={last} onChange={(e) => setLast(e.target.value)} className="w-full bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm" />
             </div>
           </div>
 
@@ -96,7 +96,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
             <span className={`text-xs ${T_SUBTLE}`}>{rating}/5</span>
           </div>
 
-          <div className="pt-2 border-t border-neutral-800">
+          <div className="pt-2 border-t border-neutral-300 dark:border-neutral-800">
             <div className="flex items-center justify-between mb-2">
               <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
               <label className="inline-flex items-center">
@@ -110,14 +110,14 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
             {photos.length > 0 && (
               <div className="grid grid-cols-4 gap-2">
                 {photos.map((p, i) => (
-                  <img key={i} src={p} className="w-full h-20 object-cover rounded-lg border border-neutral-800" />
+                  <img key={i} src={p} className="w-full h-20 object-cover rounded-lg border border-neutral-300 dark:border-neutral-800" />
                 ))}
               </div>
             )}
           </div>
 
           <div className="flex items-center gap-2 justify-end">
-            <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>
+            <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}>
               {t("Annuler")}
             </Button>
             <Button className={BTN} onClick={create}>

--- a/src/components/EditSpotModal.tsx
+++ b/src/components/EditSpotModal.tsx
@@ -29,7 +29,7 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
 
   return (
     <div ref={overlayRef} onClick={handleOutside} className="fixed inset-0 z-50 bg-black/70 grid place-items-center p-3">
-      <div className="w-full max-w-2xl bg-neutral-900 border border-neutral-800 rounded-2xl p-4">
+      <div className="w-full max-w-2xl bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl p-4">
         <div className="flex items-center justify-between mb-2">
           <div className={`text-lg font-semibold ${T_PRIMARY}`}>{t("Modifier le coin")}</div>
           <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
@@ -41,13 +41,13 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t("Nom")}
-              className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+              className={`bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
             />
             <Input
               value={location}
               onChange={(e) => setLocation(e.target.value)}
               placeholder={t("Localisation")}
-              className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+              className={`bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
             />
             <div className="flex items-center gap-2">
               <span className={`text-sm ${T_MUTED}`}>{t("Note")}</span>
@@ -61,7 +61,7 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
               <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Champignons trouvés")}</div>
               <div className="flex flex-wrap gap-2 mb-2">
                 {species.map((id) => (
-                  <span key={id} className="inline-flex items-center gap-1 bg-neutral-800 border border-neutral-700 rounded-full px-2 py-1 text-xs">
+                  <span key={id} className="inline-flex items-center gap-1 bg-neutral-200 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-full px-2 py-1 text-xs">
                     <span className={T_PRIMARY}>{MUSHROOMS.find((m) => m.id === id)?.name.split(" ")[0]}</span>
                     <button
                       onClick={() => setSpecies((list) => list.filter((x) => x !== id))}
@@ -79,7 +79,7 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
                   if (v) setSpecies((list) => (list.includes(v) ? list : [...list, v]));
                 }}
                 value=""
-                className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100"
+                className="bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm"
               >
                 <option value="" disabled>
                   {t("Ajouter un champignon…")}
@@ -92,13 +92,13 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
             <div>
               <div className={`text-sm ${T_PRIMARY}`}>{t("Dernière visite")}</div>
               <div className="mt-1">
-                <input type="date" value={last} onChange={(e) => setLast(e.target.value)} className="w-full bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100" />
+                <input type="date" value={last} onChange={(e) => setLast(e.target.value)} className="w-full bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm" />
               </div>
             </div>
           </div>
         </div>
 
-        <div className="mt-3 pt-3 border-t border-neutral-800">
+        <div className="mt-3 pt-3 border-t border-neutral-300 dark:border-neutral-800">
           <div className="flex items-center justify-between mb-2">
             <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
             <label className="inline-flex items-center">
@@ -112,14 +112,14 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
           {photos.length > 0 && (
             <div className="grid grid-cols-4 gap-2">
               {photos.map((p, i) => (
-                <img key={i} src={p} className="w-full h-20 object-cover rounded-lg border border-neutral-800" />
+                <img key={i} src={p} className="w-full h-20 object-cover rounded-lg border border-neutral-300 dark:border-neutral-800" />
               ))}
             </div>
           )}
         </div>
 
         <div className="mt-3 flex items-center gap-2 justify-end">
-          <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>
+          <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}>
             {t("Annuler")}
           </Button>
           <Button

--- a/src/components/InfoBlock.tsx
+++ b/src/components/InfoBlock.tsx
@@ -3,9 +3,9 @@ import { T_PRIMARY, T_MUTED } from "../styles/tokens";
 
 export function InfoBlock({ icon, title, text }: { icon: React.ReactNode; title: string; text: string }) {
   return (
-    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-3">
+    <div className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl p-3">
       <div className={`flex items-center gap-2 mb-1 ${T_PRIMARY}`}>
-        <div className="w-6 h-6 grid place-items-center rounded-lg bg-neutral-800 text-neutral-100">{icon}</div>
+        <div className="w-6 h-6 grid place-items-center rounded-lg bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100">{icon}</div>
         <div className="text-sm font-medium">{title}</div>
       </div>
       <div className={`text-sm ${T_MUTED}`}>{text}</div>

--- a/src/components/SelectRow.tsx
+++ b/src/components/SelectRow.tsx
@@ -18,7 +18,7 @@ export function SelectRow({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100"
+        className="bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm"
       >
         {options.map((o) => (
           <option key={o.value} value={o.value}>

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -23,14 +23,14 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
 
   return (
     <div ref={overlayRef} onClick={handleOutside} className="fixed inset-0 z-50 bg-black/70 grid place-items-center p-3">
-      <div className="w-full max-w-3xl bg-neutral-900 border border-neutral-800 rounded-2xl p-4">
+      <div className="w-full max-w-3xl bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl p-4">
         <div className="flex items-center justify-between mb-3">
           <div className={`text-lg font-semibold ${T_PRIMARY}`}>{t("Historique du coin")}</div>
           <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
         </div>
 
-        <div className="relative h-48 rounded-xl overflow-hidden border border-neutral-800 bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)]">
-          <div className={`absolute top-2 left-2 px-2 py-1 rounded-lg text-xs bg-neutral-900/70 border border-neutral-800 ${T_PRIMARY}`}>
+        <div className="relative h-48 rounded-xl overflow-hidden border border-neutral-300 dark:border-neutral-800 bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)] bg-neutral-100 dark:bg-neutral-900">
+          <div className={`absolute top-2 left-2 px-2 py-1 rounded-lg text-xs bg-neutral-100/70 dark:bg-neutral-900/70 border border-neutral-300 dark:border-neutral-800 ${T_PRIMARY}`}>
             <MapPin className="w-3 h-3 inline mr-1" />
             {t("Carte du coin")}
           </div>
@@ -48,7 +48,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
           <div className="space-y-2">
             {history.length === 0 && <div className={T_MUTED}>{t("Aucune visite enregistrée.")}</div>}
             {history.map((h, i) => (
-              <div key={i} className="flex items-start justify-between bg-neutral-900 border border-neutral-800 rounded-xl p-2">
+              <div key={i} className="flex items-start justify-between bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-xl p-2">
                 <div>
                   <div className={`text-sm ${T_PRIMARY}`}>{h.date}</div>
                   <div className={`text-xs ${T_MUTED}`}>
@@ -59,7 +59,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
                   {h.photos && h.photos.length > 0 && (
                     <div className="flex -space-x-2">
                       {h.photos.slice(0, 3).map((p: string, idx: number) => (
-                        <img key={idx} src={p} className="w-10 h-10 rounded-lg border border-neutral-800 object-cover" />
+                        <img key={idx} src={p} className="w-10 h-10 rounded-lg border border-neutral-300 dark:border-neutral-800 object-cover" />
                       ))}
                     </div>
                   )}
@@ -80,13 +80,13 @@ export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => 
             <div className="grid grid-cols-3 gap-2">
               {photos.slice(0, 5).map((p: string, i: number) => (
                 <button key={i} onClick={() => setLightbox({ open: true, index: i })} className="relative group">
-                  <img src={p} className="w-full h-28 object-cover rounded-xl border border-neutral-800" />
+                  <img src={p} className="w-full h-28 object-cover rounded-xl border border-neutral-300 dark:border-neutral-800" />
                   <div className="absolute inset-0 rounded-xl bg-black/0 group-hover:bg-black/20 transition" />
                   <Maximize2 className="absolute right-2 bottom-2 w-4 h-4 text-white opacity-0 group-hover:opacity-100" />
                 </button>
               ))}
               {photos.length > 5 && (
-                <button onClick={() => setLightbox({ open: true, index: 5 })} className="relative grid place-items-center rounded-xl border border-neutral-800 bg-neutral-900/60">
+                <button onClick={() => setLightbox({ open: true, index: 5 })} className="relative grid place-items-center rounded-xl border border-neutral-300 dark:border-neutral-800 bg-neutral-100/60 dark:bg-neutral-900/60">
                   <span className={`text-sm ${T_PRIMARY}`}>+{photos.length - 5} {t("photos")}</span>
                 </button>
               )}

--- a/src/scenes/DownloadScene.tsx
+++ b/src/scenes/DownloadScene.tsx
@@ -24,7 +24,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
         <div className="relative flex-1">
           <Input
             placeholder={t("Rechercher une zone…")}
-            className={`pl-9 bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+            className={`pl-9 bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
           />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
         </div>
@@ -32,15 +32,15 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
           <ChevronLeft className="w-5 h-5" />
         </Button>
       </div>
-      <div className="relative h-[50vh] rounded-2xl border border-neutral-800 overflow-hidden bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)]">
+      <div className="relative h-[50vh] rounded-2xl border border-neutral-300 dark:border-neutral-800 overflow-hidden bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)] bg-neutral-100 dark:bg-neutral-900">
         <div className="absolute inset-6 border-2 border-red-600 rounded-xl" />
-        <div className={`absolute top-3 left-3 bg-neutral-900/80 rounded-xl px-3 py-1 text-sm ${T_PRIMARY}`}>
+        <div className={`absolute top-3 left-3 bg-neutral-100/80 dark:bg-neutral-900/80 rounded-xl px-3 py-1 text-sm ${T_PRIMARY}`}>
           {t("Vue actuelle")}
         </div>
       </div>
 
       <div className="mt-3 grid md:grid-cols-2 gap-3">
-        <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
+        <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
           <CardContent className="pt-4 space-y-2">
             <Row label={t("Taille estimée")} value={`${packSize} Mo`} />
             <Row label={t("Espace disponible")} value={`${deviceFree} Mo`} />
@@ -59,7 +59,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
                   <Download className="w-4 h-4 mr-2" />
                   {t("Télécharger")}
                 </Button>
-                <Button variant="ghost" onClick={onCancel} className={`flex-1 rounded-xl hover:bg-neutral-800 ${T_PRIMARY}`}>
+                <Button variant="ghost" onClick={onCancel} className={`flex-1 rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}>
                   {t("Annuler")}
                 </Button>
               </div>
@@ -72,7 +72,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
           </CardContent>
         </Card>
 
-        <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
+        <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
           <CardHeader>
             <CardTitle className={T_PRIMARY}>{t("États possibles")}</CardTitle>
           </CardHeader>

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -29,7 +29,7 @@ export default function LandingScene({ onSeeMap, onMySpots, onOpenSettings, onOp
       />
       <div className="absolute inset-0 bg-black/60" />
       <div className="relative z-10 max-w-3xl mx-auto px-6 py-20 text-center">
-        <div className="mx-auto mb-6 w-20 h-20 rounded-2xl bg-neutral-800/60 border border-neutral-700 grid place-items-center shadow-xl">
+        <div className="mx-auto mb-6 w-20 h-20 rounded-2xl bg-neutral-200/60 dark:bg-neutral-800/60 border border-neutral-300 dark:border-neutral-700 grid place-items-center shadow-xl">
           <MushroomIcon className={T_PRIMARY} />
         </div>
         <h1 className={`text-3xl font-semibold ${T_PRIMARY}`}>

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -58,7 +58,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
         <div className="relative flex-1">
           <Input
             placeholder={t("Rechercher un lieu…")}
-            className={`pl-9 bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+            className={`pl-9 bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
           />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
         </div>
@@ -68,7 +68,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
         </Button>
       </div>
 
-      <div className="relative h-[60vh] rounded-2xl border border-neutral-800 overflow-hidden">
+      <div className="relative h-[60vh] rounded-2xl border border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 overflow-hidden">
         <div ref={mapContainer} className="absolute inset-0 w-full h-full" />
 
         <div className="absolute top-3 left-3 flex flex-col gap-2">
@@ -81,7 +81,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
           >
             📍
           </Button>
-          <div className="bg-neutral-900/80 backdrop-blur rounded-xl p-2 border border-neutral-800 flex items-center gap-2">
+          <div className="bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur rounded-xl p-2 border border-neutral-300 dark:border-neutral-800 flex items-center gap-2">
             <span className={`text-xs ${T_PRIMARY}`}>
               {t("Légende")} J{state.day >= 0 ? "+" : ""}
               {state.day}
@@ -97,7 +97,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
 
         <div className="absolute bottom-3 left-3 grid gap-2">
           {zones.map(z => (
-            <div key={z.id} onClick={() => onZone(z)} role="button" tabIndex={0} className="bg-neutral-900/80 hover:bg-neutral-800/80 border border-neutral-800 rounded-xl px-3 py-2 text-left cursor-pointer">
+            <div key={z.id} onClick={() => onZone(z)} role="button" tabIndex={0} className="bg-neutral-100/80 hover:bg-neutral-200/80 dark:bg-neutral-900/80 dark:hover:bg-neutral-800/80 border border-neutral-300 dark:border-neutral-800 rounded-xl px-3 py-2 text-left cursor-pointer">
               <div className="flex items-center justify-between">
                 <div className={`font-medium ${T_PRIMARY}`}>{z.name}</div>
                 <Badge variant={z.score > 85 ? "default" : "secondary"}>{z.score}%</Badge>
@@ -105,14 +105,14 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
               <div className={`text-xs ${T_MUTED}`}>{t(z.trend)}</div>
               <div className="mt-1 flex gap-1">
                 {Object.entries(z.species).map(([id, sc]) => (
-                  <span key={id} onClick={(e) => { e.stopPropagation(); onOpenShroom(id); }} className={`text-[10px] bg-neutral-800 border border-neutral-700 px-2 py-1 rounded-full hover:bg-neutral-700 ${T_PRIMARY} cursor-pointer`}>{MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0]} {sc}%</span>
+                  <span key={id} onClick={(e) => { e.stopPropagation(); onOpenShroom(id); }} className={`text-[10px] bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 dark:bg-neutral-800 dark:border-neutral-700 dark:hover:bg-neutral-700 px-2 py-1 rounded-full ${T_PRIMARY} cursor-pointer`}>{MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0]} {sc}%</span>
                 ))}
               </div>
             </div>
           ))}
         </div>
 
-        <div className="absolute bottom-3 right-3 bg-neutral-900/80 backdrop-blur rounded-xl p-2 border border-neutral-800">
+        <div className="absolute bottom-3 right-3 bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur rounded-xl p-2 border border-neutral-300 dark:border-neutral-800">
           <input type="range" min={1} max={14} value={zoom} onChange={(e) => setZoom(parseInt(e.target.value, 10))} />
         </div>
       </div>

--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -21,7 +21,7 @@ export default function MushroomScene({ item, onSeeZones, onBack }: { item: any;
       >
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <div className="rounded-2xl overflow-hidden border border-neutral-800">
+      <div className="rounded-2xl overflow-hidden border border-neutral-300 dark:border-neutral-800">
         <img src={item.photo} className="w-full h-60 object-cover" />
       </div>
 

--- a/src/scenes/PickerScene.tsx
+++ b/src/scenes/PickerScene.tsx
@@ -20,15 +20,15 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t("Rechercher un champignon…")}
-          className={`bg-neutral-900 border-neutral-800 ${T_PRIMARY}`}
+          className={`bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
         />
-        <select value={seasonFilter} onChange={(e) => setSeasonFilter(e.target.value)} className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
+        <select value={seasonFilter} onChange={(e) => setSeasonFilter(e.target.value)} className="bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm">
           <option value="toutes">{t("Toutes saisons")}</option>
           <option>{t("Printemps")}</option>
           <option>{t("Été")}</option>
           <option>{t("Automne")}</option>
         </select>
-        <select value={valueFilter} onChange={(e) => setValueFilter(e.target.value)} className="bg-neutral-900 border border-neutral-800 rounded-xl px-3 py-2 text-sm text-neutral-100">
+        <select value={valueFilter} onChange={(e) => setValueFilter(e.target.value)} className="bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm">
           <option value="toutes">{t("Toute valeur")}</option>
           <option>{t("Excellente")}</option>
           <option>{t("Bonne")}</option>
@@ -38,7 +38,7 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
 
       <div className="grid md:grid-cols-3 gap-3">
         {items.map(m => (
-          <button key={m.id} onClick={() => onPick(m)} className="text-left bg-neutral-900 border border-neutral-800 rounded-2xl overflow-hidden hover:border-neutral-700">
+          <button key={m.id} onClick={() => onPick(m)} className="text-left bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl overflow-hidden hover:border-neutral-400 dark:hover:border-neutral-700">
             <img src={m.photo} className="w-full h-40 object-cover" />
             <div className="p-3">
               <div className={`font-medium ${T_PRIMARY}`}>{m.name}</div>

--- a/src/scenes/RouteScene.tsx
+++ b/src/scenes/RouteScene.tsx
@@ -12,7 +12,7 @@ export default function RouteScene({ onBackToMap, onBack }: { onBackToMap: () =>
       <Button variant="ghost" size="icon" onClick={onBack} className={`${BTN_GHOST_ICON} mb-3`} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <div className="relative h-[60vh] rounded-2xl border border-neutral-800 overflow-hidden bg-neutral-900 grid">
+      <div className="relative h-[60vh] rounded-2xl border border-neutral-300 dark:border-neutral-800 overflow-hidden bg-neutral-100 dark:bg-neutral-900 grid">
         <div className={`p-3 text-sm ${T_MUTED}`}>
           {t("Instructions étape par étape (démo) :")}
           <br />🚗 {t("Rejoindre parking")} → 🚶 {t("Sentier balisé")} → 🧭 {t("Boussole sur 250 m")}

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -18,7 +18,7 @@ export default function SettingsScene({ onOpenPacks, onBack }: { onOpenPacks: ()
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
+      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
         <CardHeader>
           <CardTitle className={T_PRIMARY}>{t("Cartes hors‑ligne")}</CardTitle>
         </CardHeader>
@@ -36,7 +36,7 @@ export default function SettingsScene({ onOpenPacks, onBack }: { onOpenPacks: ()
         </CardContent>
       </Card>
 
-      <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
+      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
         <CardHeader>
           <CardTitle className={T_PRIMARY}>{t("Alertes")}</CardTitle>
         </CardHeader>
@@ -54,7 +54,7 @@ export default function SettingsScene({ onOpenPacks, onBack }: { onOpenPacks: ()
         </CardContent>
       </Card>
 
-      <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
+      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
         <CardHeader>
           <CardTitle className={T_PRIMARY}>{t("Préférences")}</CardTitle>
         </CardHeader>

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -47,13 +47,13 @@ export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; o
       <div className="grid md:grid-cols-2 gap-3">
         {spots.length === 0 && <div className={T_PRIMARY}>{t("Aucun coin enregistré.")}</div>}
         {spots.map(s => (
-          <Card key={s.id} className="bg-neutral-900 border-neutral-800 rounded-2xl overflow-hidden relative">
+          <Card key={s.id} className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl overflow-hidden relative">
             <button onClick={() => setDetails(s)} className="block text-left">
               <img src={s.cover || s.photo} className="w-full h-40 object-cover" />
             </button>
             <button
               onClick={() => setEditing(s)}
-              className="absolute top-2 right-2 bg-neutral-900/80 hover:bg-neutral-800/80 border border-neutral-700 rounded-full p-2"
+              className="absolute top-2 right-2 bg-neutral-100/80 hover:bg-neutral-200/80 dark:bg-neutral-900/80 dark:hover:bg-neutral-800/80 border border-neutral-300 dark:border-neutral-700 rounded-full p-2"
               aria-label={t("modifier")}
             >
               <Pencil className="w-4 h-4 text-neutral-200" />

--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -26,7 +26,7 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
       >
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <Card className="bg-neutral-900 border-neutral-800 rounded-2xl">
+      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
         <CardHeader>
           <CardTitle className={`flex items-center justify-between ${T_PRIMARY}`}>
             <div>
@@ -56,7 +56,7 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
               {Object.entries(zone.species).filter(([_, v]) => v > 0).map(([id, sc]) => {
                 const m = MUSHROOMS.find(m => m.id === id);
                 return (
-                  <button key={id} onClick={() => onOpenShroom(id)} className={`bg-neutral-800 border border-neutral-700 rounded-xl p-2 hover:bg-neutral-700 ${T_PRIMARY}`}>
+                  <button key={id} onClick={() => onOpenShroom(id)} className={`bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 dark:bg-neutral-800 dark:border-neutral-700 dark:hover:bg-neutral-700 rounded-xl p-2 ${T_PRIMARY}`}>
                     <div className="flex items-center gap-2">
                       <img src={m.photo} className="w-12 h-12 object-cover rounded-lg" />
                       <div>

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,5 +1,7 @@
-export const BTN = "rounded-xl bg-neutral-300 text-neutral-900 hover:bg-neutral-200";
-export const BTN_GHOST_ICON = "text-neutral-300 hover:bg-neutral-800";
-export const T_PRIMARY = "text-neutral-100";
-export const T_MUTED = "text-neutral-300";
-export const T_SUBTLE = "text-neutral-400";
+export const BTN =
+  "rounded-xl bg-neutral-200 text-neutral-900 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-600";
+export const BTN_GHOST_ICON =
+  "text-neutral-900 hover:bg-neutral-200 dark:text-neutral-300 dark:hover:bg-neutral-800";
+export const T_PRIMARY = "text-neutral-900 dark:text-neutral-100";
+export const T_MUTED = "text-neutral-600 dark:text-neutral-300";
+export const T_SUBTLE = "text-neutral-500 dark:text-neutral-400";


### PR DESCRIPTION
## Summary
- implement theme preference handling and toggle document class
- introduce light and dark style tokens
- update components and scenes to support dual-mode UI

## Testing
- `npm test` (fails: Could not read package.json)
- `npx tsc --noEmit -p tsconfig.json` (fails: Cannot find module 'react')

------
https://chatgpt.com/codex/tasks/task_e_68990417d864832999a7770215aaf849