### PR TITLE
feat: add basic ui component library

### DIFF
--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import { X, Images } from "lucide-react";
+import { X, Image } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MUSHROOMS } from "../data/mushrooms";
@@ -102,7 +102,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
               <label className="inline-flex items-center">
                 <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
                 <Button type="button" className={BTN}>
-                  <Images className="w-4 h-4 mr-2" />
+                  <Image className="w-4 h-4 mr-2" />
                   {t("Importer des photos")}
                 </Button>
               </label>

--- a/src/components/EditSpotModal.tsx
+++ b/src/components/EditSpotModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import { X, Images } from "lucide-react";
+import { X, Image } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MUSHROOMS } from "../data/mushrooms";
@@ -103,8 +103,8 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: (
             <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
             <label className="inline-flex items-center">
               <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
-              <Button type="button" className={BTN}>
-                <Images className="w-4 h-4 mr-2" />
+                <Button type="button" className={BTN}>
+                  <Image className="w-4 h-4 mr-2" />
                 {t("Importer des photos")}
               </Button>
             </label>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: "default" | "secondary";
+}
+
+export function Badge({ variant = "default", className = "", ...props }: BadgeProps) {
+  const base = "inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium";
+  const variants = {
+    default: "border-neutral-300 bg-neutral-200 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100",
+    secondary: "border-neutral-300 bg-neutral-300 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-700 dark:text-neutral-100",
+  } as const;
+  return <span className={`${base} ${variants[variant]} ${className}`} {...props} />;
+}
+

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "ghost";
+  size?: "default" | "icon";
+}
+
+export function Button({ variant = "default", size = "default", className = "", ...props }: ButtonProps) {
+  const base = "inline-flex items-center justify-center rounded-xl text-sm font-medium transition-colors focus:outline-none disabled:opacity-50";
+  const variants = {
+    default: "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-600",
+    ghost: "bg-transparent hover:bg-neutral-100 dark:hover:bg-neutral-800",
+  } as const;
+  const sizes = {
+    default: "px-3 py-2",
+    icon: "h-10 w-10 p-0",
+  } as const;
+  const classes = `${base} ${variants[variant]} ${sizes[size]} ${className}`;
+  return <button className={classes} {...props} />;
+}
+

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export function Card({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const base = "rounded-2xl border border-neutral-300 bg-neutral-100 text-neutral-900 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100";
+  return <div className={`${base} ${className}`} {...props} />;
+}
+
+export function CardHeader({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`p-4 border-b border-neutral-300 dark:border-neutral-800 ${className}`} {...props} />;
+}
+
+export function CardTitle({ className = "", ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={`text-lg font-semibold ${className}`} {...props} />;
+}
+
+export function CardContent({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`p-4 ${className}`} {...props} />;
+}
+

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export function Input({ className = "", ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
+  const base = "flex h-10 w-full rounded-xl border border-neutral-300 bg-neutral-100 px-3 py-2 text-sm text-neutral-900 focus:outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100";
+  return <input className={`${base} ${className}`} {...props} />;
+}
+

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface ProgressProps {
+  value?: number;
+  className?: string;
+}
+
+export function Progress({ value = 0, className = "" }: ProgressProps) {
+  return (
+    <div className={`w-full h-2 rounded-full bg-neutral-200 dark:bg-neutral-800 ${className}`}>
+      <div
+        className="h-2 rounded-full bg-neutral-900 dark:bg-neutral-100 transition-all"
+        style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+      />
+    </div>
+  );
+}
+

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface SwitchProps {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  className?: string;
+}
+
+export function Switch({ checked = false, onCheckedChange, className = "" }: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange?.(!checked)}
+      className={`relative inline-flex h-6 w-10 items-center rounded-full border border-neutral-300 bg-neutral-200 transition-colors dark:border-neutral-700 dark:bg-neutral-800 ${checked ? "bg-neutral-700 dark:bg-neutral-300" : ""} ${className}`}
+    >
+      <span
+        className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow transform transition-transform dark:bg-neutral-900 ${checked ? "translate-x-4" : "translate-x-0"}`}
+      />
+    </button>
+  );
+}
+

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -13,7 +13,7 @@ import mapboxgl from "mapbox-gl";
 import { useAppContext } from "../context/AppContext";
 import { useT } from "../i18n";
 
-export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow, onBack }: { onZone: (z: any) => void; onOpenShroom: (id: string) => void; gpsFollow: boolean; setGpsFollow: (v: (p: boolean) => boolean | boolean) => void; onBack: () => void }) {
+export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow, onBack }: { onZone: (z: any) => void; onOpenShroom: (id: string) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onBack: () => void }) {
   const [selectedSpecies, setSelectedSpecies] = useState<string[]>([]);
   const [zoom, setZoom] = useState(5);
   const mapContainer = useRef<HTMLDivElement>(null);

--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { ChevronLeft, Calendar, Trees, CloudSun, Info, ChefHat, Sandwich, TriangleAlert, Compass, MapPin } from "lucide-react";
+import { ChevronLeft, Calendar, Trees, CloudSun, Info, ChefHat, Sandwich, AlertTriangle, Compass, MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { InfoBlock } from "../components/InfoBlock";
@@ -47,7 +47,7 @@ export default function MushroomScene({ item, onSeeZones, onBack }: { item: any;
         />
         <InfoBlock icon={<Sandwich className="w-4 h-4" />} title={t("Exemples de plats")} text={item.dishes.join(" • ")} />
         <InfoBlock
-          icon={<TriangleAlert className="w-4 h-4" />}
+          icon={<AlertTriangle className="w-4 h-4" />}
           title={t("Confusions possibles")}
           text={item.confusions.join(" • ")}
         />

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -49,7 +49,7 @@ export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; o
         {spots.map(s => (
           <Card key={s.id} className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl overflow-hidden relative">
             <button onClick={() => setDetails(s)} className="block text-left">
-              <img src={s.cover || s.photo} className="w-full h-40 object-cover" />
+              <img src={s.cover || s.photos?.[0]} className="w-full h-40 object-cover" />
             </button>
             <button
               onClick={() => setEditing(s)}

--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -53,7 +53,7 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
           <div className="mt-4">
             <div className={`text-sm mb-2 ${T_PRIMARY}`}>{t("Comestibles probables")}</div>
             <div className="flex flex-wrap gap-2">
-              {Object.entries(zone.species).filter(([_, v]) => v > 0).map(([id, sc]) => {
+              {Object.entries(zone.species as Record<string, number>).filter(([_, v]) => v > 0).map(([id, sc]) => {
                 const m = MUSHROOMS.find(m => m.id === id);
                 return (
                   <button key={id} onClick={() => onOpenShroom(id)} className={`bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 dark:bg-neutral-800 dark:border-neutral-700 dark:hover:bg-neutral-700 rounded-xl p-2 ${T_PRIMARY}`}>


### PR DESCRIPTION
## Summary
- add reusable Button, Input, Card, Badge, Switch and Progress components under `src/components/ui`
- update scenes and modals to use new primitives and fix icon imports and typing
- confirm existing `@/*` path mapping resolves new components

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68990bf496d08329b6d780f2912c691f