### PR TITLE
build: use vite build with alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "vite build",
     "start": "tsx -r tsconfig-paths/register src/App.tsx",
     "test": "echo \"No tests specified\" && exit 0",
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite alias for `@` to resolve to `src`
- switch project build script to use `vite build`

## Testing
- `npm run build`
- `npm test`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68991c554ce88329981fd001c6c2a930