### PR TITLE
Handle network errors in data loader

### DIFF
--- a/src/services/dataLoader.test.ts
+++ b/src/services/dataLoader.test.ts
@@ -1,0 +1,19 @@
+import assert from "assert/strict";
+import { fetchJSON, loadMushrooms } from "./dataLoader";
+
+(async () => {
+  // Mock fetch to simulate a network failure
+  (global as any).fetch = () => Promise.reject(new Error("network down"));
+  (global as any).alert = () => {};
+
+  await assert.rejects(() => fetchJSON("/test"), /Network error/);
+
+  const fallback = [{ id: "1" }];
+  const res = await fetchJSON("/test", fallback);
+  assert.deepStrictEqual(res, fallback);
+
+  const mushrooms = await loadMushrooms();
+  assert.deepStrictEqual(mushrooms, []);
+
+  console.log("tests passed");
+})();

--- a/src/services/dataLoader.ts
+++ b/src/services/dataLoader.ts
@@ -1,15 +1,45 @@
 import type { Mushroom, Zone } from "../types";
 
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Failed to load ${url}`);
+export async function fetchJSON<T>(url: string, fallback?: T): Promise<T> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to load ${url}`);
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error(`Network error while fetching ${url}`);
   }
-  return res.json() as Promise<T>;
 }
 
-export const loadMushrooms = () => fetchJSON<Mushroom[]>("/data/mushrooms.json");
-export const loadZones = () => fetchJSON<Zone[]>("/data/zones.json");
-export const loadLegend = () => fetchJSON<{ label: string; color: string }[]>("/data/legend.json");
+export const loadMushrooms = async () => {
+  try {
+    return await fetchJSON<Mushroom[]>("/data/mushrooms.json");
+  } catch (err) {
+    alert("Impossible de charger les champignons.");
+    return [];
+  }
+};
+
+export const loadZones = async () => {
+  try {
+    return await fetchJSON<Zone[]>("/data/zones.json");
+  } catch (err) {
+    alert("Impossible de charger les zones.");
+    return [];
+  }
+};
+
+export const loadLegend = async () => {
+  try {
+    return await fetchJSON<{ label: string; color: string }[]>("/data/legend.json");
+  } catch (err) {
+    alert("Impossible de charger la légende.");
+    return [];
+  }
+};
 
 export default { loadMushrooms, loadZones, loadLegend };


### PR DESCRIPTION
## Summary
- wrap fetchJSON in try/catch with optional fallback and clearer errors
- alert users and provide fallbacks in loadMushrooms/loadZones/loadLegend
- add basic test simulating network failure

## Testing
- `npm test`
- `npx tsx src/services/dataLoader.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689928ec57cc8329a7f06a403849cd36