### PR TITLE
feat: localize forecast dates

### DIFF
--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -9,10 +9,12 @@ import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tok
 import { MUSHROOMS } from "../data/mushrooms";
 import { generateForecast } from "../utils";
 import { useT } from "../i18n";
+import { useAppContext } from "../context/AppContext";
 
 export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: { zone: any; onGo: () => void; onAdd: () => void; onOpenShroom: (id: string) => void; onBack: () => void }) {
   const { t } = useT();
-  const data = useMemo(() => generateForecast(), [zone?.id]);
+  const { state } = useAppContext();
+  const data = useMemo(() => generateForecast(state.prefs.lang), [zone?.id, state.prefs.lang]);
   if (!zone)
     return <div className={`p-6 ${T_PRIMARY}`}>{t("Sélectionnez une zone…")}</div>;
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,15 +2,18 @@ export function classNames(...c: (string | false | null | undefined)[]) {
   return c.filter(Boolean).join(" ");
 }
 
-export function generateForecast() {
+export function generateForecast(lang: string) {
   const days = [] as { day: string; score: number }[];
   const today = new Date();
   for (let i = -7; i <= 7; i++) {
     const d = new Date(today);
     d.setDate(today.getDate() + i);
     days.push({
-      day: d.toLocaleDateString("fr-FR", { day: "2-digit", month: "2-digit" }),
-      score: Math.max(10, Math.min(100, Math.round(60 + 25 * Math.sin(i / 2) + (Math.random() * 10 - 5))))
+      day: d.toLocaleDateString(lang === "fr" ? "fr-FR" : "en-US", { day: "2-digit", month: "2-digit" }),
+      score: Math.max(
+        10,
+        Math.min(100, Math.round(60 + 25 * Math.sin(i / 2) + (Math.random() * 10 - 5)))
+      )
     });
   }
   return days;


### PR DESCRIPTION
## Summary
- pass language to `generateForecast` for locale-sensitive dates
- retrieve app language from context in `ZoneScene`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689928e36e508329bdf8e97f83f649ff