### PR TITLE
chore: replace any with domain types

### DIFF
--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -6,8 +6,9 @@ import { MUSHROOMS } from "../data/mushrooms";
 import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { StarRating } from "./StarRating";
 import { useT } from "../i18n";
+import type { Spot } from "../types";
 
-export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; onCreate: (spot: any) => void }) {
+export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; onCreate: (spot: Spot) => void }) {
   const today = new Date().toISOString().slice(0, 10);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const { t } = useT();

--- a/src/components/EditSpotModal.tsx
+++ b/src/components/EditSpotModal.tsx
@@ -6,8 +6,9 @@ import { MUSHROOMS } from "../data/mushrooms";
 import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { StarRating } from "./StarRating";
 import { useT } from "../i18n";
+import type { Spot } from "../types";
 
-export function EditSpotModal({ spot, onClose, onSave }: { spot: any; onClose: () => void; onSave: (s: any) => void }) {
+export function EditSpotModal({ spot, onClose, onSave }: { spot: Spot; onClose: () => void; onSave: (s: Spot) => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const [name, setName] = useState(spot.name);
   const [rating, setRating] = useState(spot.rating || 3);

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -3,12 +3,13 @@ import { X, MapPin, Plus, Pencil, Maximize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { useT } from "../i18n";
+import type { Spot, VisitHistory } from "../types";
 
-export function SpotDetailsModal({ spot, onClose }: { spot: any; onClose: () => void }) {
+export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
-  const [lightbox, setLightbox] = useState({ open: false, index: 0 });
+  const [lightbox, setLightbox] = useState<{ open: boolean; index: number }>({ open: false, index: 0 });
   const photos = spot.photos || [];
-  const [history, setHistory] = useState(
+  const [history, setHistory] = useState<VisitHistory[]>(
     spot.history || (spot.visits || []).map((d: string) => ({ date: d, rating: spot.rating, note: "", photos: [] }))
   );
   const { t } = useT();

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -12,8 +12,9 @@ import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tok
 import mapboxgl from "mapbox-gl";
 import { useT } from "../i18n";
 import { NotificationStack, Notification } from "../components/NotificationStack";
+import type { Zone } from "../types";
 
-export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow, onBack }: { onZone: (z: any) => void; onOpenShroom: (id: string) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onBack: () => void }) {
+export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow, onBack }: { onZone: (z: Zone) => void; onOpenShroom: (id: string) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onBack: () => void }) {
   const [selectedSpecies, setSelectedSpecies] = useState<string[]>([]);
   const [zoom, setZoom] = useState(5);
   const mapContainer = useRef<HTMLDivElement>(null);
@@ -65,7 +66,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
       mapRef.current.setZoom(zoom);
     }
   }, [zoom]);
-  const zones = useMemo(() => (selectedSpecies.length === 0 ? DEMO_ZONES : DEMO_ZONES.filter(z => selectedSpecies.every(id => (z.species[id] || 0) > 50))), [selectedSpecies]);
+  const zones = useMemo<Zone[]>(() => (selectedSpecies.length === 0 ? DEMO_ZONES : DEMO_ZONES.filter(z => selectedSpecies.every(id => (z.species[id] || 0) > 50))), [selectedSpecies]);
 
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">

--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -6,8 +6,9 @@ import { Badge } from "@/components/ui/badge";
 import { InfoBlock } from "../components/InfoBlock";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_SUBTLE } from "../styles/tokens";
 import { useT } from "../i18n";
+import type { Mushroom } from "../types";
 
-export default function MushroomScene({ item, onSeeZones, onBack }: { item: any; onSeeZones: () => void; onBack: () => void }) {
+export default function MushroomScene({ item, onSeeZones, onBack }: { item: Mushroom; onSeeZones: () => void; onBack: () => void }) {
   const { t } = useT();
   if (!item) return <div className={`p-6 ${T_PRIMARY}`}>{t("Sélectionnez un champignon…")}</div>;
   return (

--- a/src/scenes/PickerScene.tsx
+++ b/src/scenes/PickerScene.tsx
@@ -5,8 +5,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { useT } from "../i18n";
+import type { Mushroom } from "../types";
 
-export default function PickerScene({ items, search, setSearch, onPick, onBack }: { items: any[]; search: string; setSearch: (v: string) => void; onPick: (m: any) => void; onBack: () => void }) {
+export default function PickerScene({ items, search, setSearch, onPick, onBack }: { items: Mushroom[]; search: string; setSearch: (v: string) => void; onPick: (m: Mushroom) => void; onBack: () => void }) {
   const [seasonFilter, setSeasonFilter] = useState("toutes");
   const [valueFilter, setValueFilter] = useState("toutes");
   const { t } = useT();

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -9,13 +9,14 @@ import { EditSpotModal } from "../components/EditSpotModal";
 import { SpotDetailsModal } from "../components/SpotDetailsModal";
 import { useAppContext } from "../context/AppContext";
 import { useT } from "../i18n";
+import type { Spot } from "../types";
 
 export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; onBack: () => void }) {
   const { state, dispatch } = useAppContext();
   const spots = state.mySpots;
   const [createOpen, setCreateOpen] = useState(false);
-  const [editing, setEditing] = useState<any>(null);
-  const [details, setDetails] = useState<any>(null);
+  const [editing, setEditing] = useState<Spot | null>(null);
+  const [details, setDetails] = useState<Spot | null>(null);
   const { t } = useT();
 
   return (

--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -10,8 +10,9 @@ import { MUSHROOMS } from "../data/mushrooms";
 import { generateForecast } from "../utils";
 import { useT } from "../i18n";
 import { useAppContext } from "../context/AppContext";
+import type { Zone } from "../types";
 
-export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: { zone: any; onGo: () => void; onAdd: () => void; onOpenShroom: (id: string) => void; onBack: () => void }) {
+export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: { zone: Zone; onGo: () => void; onAdd: () => void; onOpenShroom: (id: string) => void; onBack: () => void }) {
   const { t } = useT();
   const { state } = useAppContext();
   const data = useMemo(() => generateForecast(state.prefs.lang), [zone?.id, state.prefs.lang]);


### PR DESCRIPTION
## Summary
- replace `any` in components and scenes with `Spot`, `Mushroom`, and `Zone` types
- type component state and callbacks explicitly

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68992cac8d648329afa390083fd44201