### PR TITLE
refactor: remove service alerts

### DIFF
--- a/src/services/dataLoader.test.ts
+++ b/src/services/dataLoader.test.ts
@@ -4,7 +4,6 @@ import { fetchJSON, loadMushrooms } from "./dataLoader";
 (async () => {
   // Mock fetch to simulate a network failure
   (global as any).fetch = () => Promise.reject(new Error("network down"));
-  (global as any).alert = () => {};
 
   await assert.rejects(() => fetchJSON("/test"), /Network error/);
 
@@ -12,8 +11,7 @@ import { fetchJSON, loadMushrooms } from "./dataLoader";
   const res = await fetchJSON("/test", fallback);
   assert.deepStrictEqual(res, fallback);
 
-  const mushrooms = await loadMushrooms();
-  assert.deepStrictEqual(mushrooms, []);
+  await assert.rejects(() => loadMushrooms(), /Network error/);
 
   console.log("tests passed");
 })();

--- a/src/services/dataLoader.ts
+++ b/src/services/dataLoader.ts
@@ -15,31 +15,13 @@ export async function fetchJSON<T>(url: string, fallback?: T): Promise<T> {
   }
 }
 
-export const loadMushrooms = async () => {
-  try {
-    return await fetchJSON<Mushroom[]>("/data/mushrooms.json");
-  } catch (err) {
-    alert("Impossible de charger les champignons.");
-    return [];
-  }
-};
+export const loadMushrooms = () =>
+  fetchJSON<Mushroom[]>("/data/mushrooms.json");
 
-export const loadZones = async () => {
-  try {
-    return await fetchJSON<Zone[]>("/data/zones.json");
-  } catch (err) {
-    alert("Impossible de charger les zones.");
-    return [];
-  }
-};
+export const loadZones = () =>
+  fetchJSON<Zone[]>("/data/zones.json");
 
-export const loadLegend = async () => {
-  try {
-    return await fetchJSON<{ label: string; color: string }[]>("/data/legend.json");
-  } catch (err) {
-    alert("Impossible de charger la légende.");
-    return [];
-  }
-};
+export const loadLegend = () =>
+  fetchJSON<{ label: string; color: string }[]>("/data/legend.json");
 
 export default { loadMushrooms, loadZones, loadLegend };


### PR DESCRIPTION
## Summary
- remove alert calls from data loader service
- update service test to expect error propagation

## Testing
- `npm test`
- `npx tsx src/services/dataLoader.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68992cab14e0832993c84089e658b1e0