### PR TITLE
refactor: add todayISO utility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useEffect, useCallback } from "react";
 import { AnimatePresence } from "framer-motion";
 import { Routes, Route, useNavigate, useLocation, Navigate } from "react-router-dom";
-import { classNames } from "./utils";
+import { classNames, todayISO } from "./utils";
 import { T_PRIMARY } from "./styles/tokens";
 import type { Mushroom, Zone, Spot } from "./types";
 import { MUSHROOMS } from "./data/mushrooms";
@@ -143,7 +143,7 @@ function AppContent() {
                   zone={selectedZone}
                   onGo={() => goTo(Scene.Route)}
                   onAdd={() => {
-                    const today = new Date().toISOString().slice(0, 10);
+                    const today = todayISO();
                     dispatch({
                       type: "addSpot",
                       spot: {

--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -7,9 +7,10 @@ import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { StarRating } from "./StarRating";
 import { useT } from "../i18n";
 import type { Spot } from "../types";
+import { todayISO } from "../utils";
 
 export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; onCreate: (spot: Spot) => void }) {
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayISO();
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const { t, lang } = useT();
   const [name, setName] = useState("");

--- a/src/components/EditSpotModal.tsx
+++ b/src/components/EditSpotModal.tsx
@@ -7,13 +7,14 @@ import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { StarRating } from "./StarRating";
 import { useT } from "../i18n";
 import type { Spot } from "../types";
+import { todayISO } from "../utils";
 
 export function EditSpotModal({ spot, onClose, onSave }: { spot: Spot; onClose: () => void; onSave: (s: Spot) => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const [name, setName] = useState(spot.name);
   const [rating, setRating] = useState(spot.rating || 3);
   const [species, setSpecies] = useState<string[]>(spot.species || []);
-  const [last, setLast] = useState(spot.last || new Date().toISOString().slice(0, 10));
+  const [last, setLast] = useState(spot.last || todayISO());
   const [location, setLocation] = useState(spot.location || "");
   const [photos, setPhotos] = useState<string[]>(spot.photos || [spot.cover].filter(Boolean));
   const photoUrlsRef = useRef<string[]>([]);

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { useT } from "../i18n";
 import type { Spot, VisitHistory } from "../types";
+import { todayISO } from "../utils";
 
 export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -18,7 +19,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
     if (e.target === overlayRef.current) onClose();
   };
   const addVisit = () => {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayISO();
     setHistory((h) => [...h, { date: today, rating: 0, note: "", photos: [] }]);
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,3 +18,7 @@ export function generateForecast(lang: string) {
   }
   return days;
 }
+
+export function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary
- add todayISO helper for consistent ISO date strings
- use todayISO in spot creation, editing, visit history, and zone spot creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899340796ec832988a3da43f0f9660c