### PR TITLE
Switch to @tailwindcss/postcss for Tailwind integration

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` instead of the old `tailwindcss` plugin in PostCSS config

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899368482008329ba41c24115f478d5