### PR TITLE
Enable dark mode switch

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind configuration so settings theme toggle works

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899389fa13c8329989cac4f17374578