### PR TITLE
feat: add minimap location selector

### DIFF
--- a/src/i18n/common.ts
+++ b/src/i18n/common.ts
@@ -74,6 +74,10 @@ export default {
     fr: "Localisation (coordonnées ou lieu)",
     en: "Location (coordinates or place)",
   },
+  "Déplacez la carte pour choisir la localisation": {
+    fr: "Déplacez la carte pour choisir la localisation",
+    en: "Move the map to choose the location",
+  },
   "Sélectionnez un champignon…": { fr: "Sélectionnez un champignon…", en: "Select a mushroom…" },
   "comestible": { fr: "comestible", en: "edible" },
   "toxique": { fr: "toxique", en: "toxic" },


### PR DESCRIPTION
## Summary
- replace manual location input with interactive minimap and fixed center pin
- add translation for map-based location selection guidance

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899395eb100832994c40d553979f3f3