### PR TITLE
Fix non-functional back arrow in SpotsScene

### DIFF
--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -31,7 +31,7 @@ export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; o
         >
           <ChevronLeft className="w-5 h-5" />
         </Button>
-        <h2 className={`absolute inset-0 grid place-items-center text-lg font-semibold ${T_PRIMARY}`}>
+        <h2 className={`absolute inset-0 grid place-items-center text-lg font-semibold pointer-events-none ${T_PRIMARY}`}>
           {t("Mes coins")}
         </h2>
       </div>


### PR DESCRIPTION
## Summary
- make "Mes coins" scene header ignore pointer events so the back arrow works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68998ce38ce08329a92abdbb6031f099