### PR TITLE
Add privacy policy scene and translations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import PickerScene from "./scenes/PickerScene";
 import MushroomScene from "./scenes/MushroomScene";
 import SettingsScene from "./scenes/SettingsScene";
 import DownloadScene from "./scenes/DownloadScene";
+import PrivacyPolicyScene from "./scenes/PrivacyPolicyScene";
 import { AppProvider, useAppContext } from "./context/AppContext";
 import { useT } from "./i18n";
 import { Scene } from "./routes";
@@ -200,7 +201,13 @@ function AppContent() {
             />
             <Route
               path={Scene.Settings}
-              element={<SettingsScene onOpenPacks={() => goTo(Scene.Download)} onBack={goBack} />}
+              element={
+                <SettingsScene
+                  onOpenPacks={() => goTo(Scene.Download)}
+                  onOpenPrivacy={() => goTo(Scene.Privacy)}
+                  onBack={goBack}
+                />
+              }
             />
             <Route
               path={Scene.Download}
@@ -231,6 +238,10 @@ function AppContent() {
                   onBack={goBack}
                 />
               }
+            />
+            <Route
+              path={Scene.Privacy}
+              element={<PrivacyPolicyScene onBack={goBack} />}
             />
             <Route path="*" element={<Navigate to={Scene.Landing} replace />} />
           </Routes>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import common from './common';
 import landing from './landing';
 import settings from './settings';
+import privacy from './privacy';
 import { useAppContext } from '../context/AppContext';
 
 export const TRANSLATIONS: Record<string, { fr: string; en: string }> = Object.assign(
@@ -8,6 +9,7 @@ export const TRANSLATIONS: Record<string, { fr: string; en: string }> = Object.a
   common,
   landing,
   settings,
+  privacy,
 );
 
 export function useT() {

--- a/src/i18n/privacy.ts
+++ b/src/i18n/privacy.ts
@@ -1,0 +1,18 @@
+export default {
+  "Politique de confidentialité": {
+    fr: "Politique de confidentialité",
+    en: "Privacy Policy",
+  },
+  "Nous ne collectons aucune donnée personnelle. Les informations restent sur votre appareil.": {
+    fr: "Nous ne collectons aucune donnée personnelle. Les informations restent sur votre appareil.",
+    en: "We do not collect any personal data. Information stays on your device.",
+  },
+  "Aucune donnée n'est transmise à des serveurs externes sans votre consentement explicite.": {
+    fr: "Aucune donnée n'est transmise à des serveurs externes sans votre consentement explicite.",
+    en: "No data is sent to external servers without your explicit consent.",
+  },
+  "L'utilisation de l'application implique l'acceptation de cette politique.": {
+    fr: "L'utilisation de l'application implique l'acceptation de cette politique.",
+    en: "Using the application implies acceptance of this policy.",
+  },
+};

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,5 +7,6 @@ export enum Scene {
   Picker = '/picker',
   Mushroom = '/mushroom',
   Settings = '/settings',
-  Download = '/download'
+  Download = '/download',
+  Privacy = '/privacy'
 }

--- a/src/scenes/PrivacyPolicyScene.tsx
+++ b/src/scenes/PrivacyPolicyScene.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
+import { useT } from "../i18n";
+
+export default function PrivacyPolicyScene({ onBack }: { onBack: () => void }) {
+  const { t } = useT();
+  return (
+    <motion.section
+      initial={{ x: 20, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: -20, opacity: 0 }}
+      className="p-3 space-y-3"
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onBack}
+        className={BTN_GHOST_ICON}
+        aria-label={t("Retour")}
+      >
+        <ChevronLeft className="w-5 h-5" />
+      </Button>
+      <h1 className={`text-xl font-bold ${T_PRIMARY}`}>{t("Politique de confidentialité")}</h1>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Nous ne collectons aucune donnée personnelle. Les informations restent sur votre appareil."
+        )}
+      </p>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Aucune donnée n'est transmise à des serveurs externes sans votre consentement explicite."
+        )}
+      </p>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t("L'utilisation de l'application implique l'acceptation de cette politique.")}
+      </p>
+    </motion.section>
+  );
+}

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -9,12 +9,25 @@ import { SelectRow } from "../components/SelectRow";
 import { useAppContext } from "../context/AppContext";
 import { useT } from "../i18n";
 
-export default function SettingsScene({ onOpenPacks, onBack }: { onOpenPacks: () => void; onBack: () => void }) {
+export default function SettingsScene({
+  onOpenPacks,
+  onOpenPrivacy,
+  onBack,
+}: {
+  onOpenPacks: () => void;
+  onOpenPrivacy: () => void;
+  onBack: () => void;
+}) {
   const { state, dispatch } = useAppContext();
   const { alerts, prefs } = state;
   const { t } = useT();
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3 space-y-3">
+    <motion.section
+      initial={{ x: 20, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: -20, opacity: 0 }}
+      className="p-3 space-y-3"
+    >
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
@@ -97,6 +110,11 @@ export default function SettingsScene({ onOpenPacks, onBack }: { onOpenPacks: ()
 
       <div className={`text-sm ${T_MUTED}`}>
         {t("« À propos » • « Conseils de cueillette »")}
+      </div>
+      <div className={`text-sm ${T_MUTED}`}>
+        <button onClick={onOpenPrivacy} className="underline">
+          {t("Politique de confidentialité")}
+        </button>
       </div>
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- create privacy policy scene with legal text and translations
- expose new `/privacy` route and wire it into app navigation
- link privacy policy from settings screen

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689991768b108329a10c404925d9f8b7