### PR TITLE
feat: add terms of use page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import MushroomScene from "./scenes/MushroomScene";
 import SettingsScene from "./scenes/SettingsScene";
 import DownloadScene from "./scenes/DownloadScene";
 import PrivacyPolicyScene from "./scenes/PrivacyPolicyScene";
+import TermsScene from "./scenes/TermsScene";
 import { AppProvider, useAppContext } from "./context/AppContext";
 import { useT } from "./i18n";
 import { Scene } from "./routes";
@@ -205,6 +206,7 @@ function AppContent() {
                 <SettingsScene
                   onOpenPacks={() => goTo(Scene.Download)}
                   onOpenPrivacy={() => goTo(Scene.Privacy)}
+                  onOpenTerms={() => goTo(Scene.Terms)}
                   onBack={goBack}
                 />
               }
@@ -242,6 +244,10 @@ function AppContent() {
             <Route
               path={Scene.Privacy}
               element={<PrivacyPolicyScene onBack={goBack} />}
+            />
+            <Route
+              path={Scene.Terms}
+              element={<TermsScene onBack={goBack} />}
             />
             <Route path="*" element={<Navigate to={Scene.Landing} replace />} />
           </Routes>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -2,6 +2,7 @@ import common from './common';
 import landing from './landing';
 import settings from './settings';
 import privacy from './privacy';
+import terms from './terms';
 import { useAppContext } from '../context/AppContext';
 
 export const TRANSLATIONS: Record<string, { fr: string; en: string }> = Object.assign(
@@ -10,6 +11,7 @@ export const TRANSLATIONS: Record<string, { fr: string; en: string }> = Object.a
   landing,
   settings,
   privacy,
+  terms,
 );
 
 export function useT() {

--- a/src/i18n/terms.ts
+++ b/src/i18n/terms.ts
@@ -1,0 +1,22 @@
+export default {
+  "Conditions d'utilisation": {
+    fr: "Conditions d'utilisation",
+    en: "Terms of Use",
+  },
+  "En utilisant cette application, vous acceptez les conditions suivantes.": {
+    fr: "En utilisant cette application, vous acceptez les conditions suivantes.",
+    en: "By using this application, you agree to the following terms.",
+  },
+  "L'utilisation doit respecter les lois locales et les réglementations.": {
+    fr: "L'utilisation doit respecter les lois locales et les réglementations.",
+    en: "Use must comply with local laws and regulations.",
+  },
+  "Les auteurs ne peuvent être tenus responsables de l'usage de l'application.": {
+    fr: "Les auteurs ne peuvent être tenus responsables de l'usage de l'application.",
+    en: "The authors cannot be held responsible for the use of the application.",
+  },
+  "L'application est fournie en l'état, sans garantie d'aucune sorte.": {
+    fr: "L'application est fournie en l'état, sans garantie d'aucune sorte.",
+    en: "The application is provided as is, without any warranty.",
+  },
+};

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,5 +8,6 @@ export enum Scene {
   Mushroom = '/mushroom',
   Settings = '/settings',
   Download = '/download',
-  Privacy = '/privacy'
+  Privacy = '/privacy',
+  Terms = '/terms'
 }

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -12,10 +12,12 @@ import { useT } from "../i18n";
 export default function SettingsScene({
   onOpenPacks,
   onOpenPrivacy,
+  onOpenTerms,
   onBack,
 }: {
   onOpenPacks: () => void;
   onOpenPrivacy: () => void;
+  onOpenTerms: () => void;
   onBack: () => void;
 }) {
   const { state, dispatch } = useAppContext();
@@ -114,6 +116,11 @@ export default function SettingsScene({
       <div className={`text-sm ${T_MUTED}`}>
         <button onClick={onOpenPrivacy} className="underline">
           {t("Politique de confidentialité")}
+        </button>
+      </div>
+      <div className={`text-sm ${T_MUTED}`}>
+        <button onClick={onOpenTerms} className="underline">
+          {t("Conditions d'utilisation")}
         </button>
       </div>
     </motion.section>

--- a/src/scenes/TermsScene.tsx
+++ b/src/scenes/TermsScene.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
+import { useT } from "../i18n";
+
+export default function TermsScene({ onBack }: { onBack: () => void }) {
+  const { t } = useT();
+  return (
+    <motion.section
+      initial={{ x: 20, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: -20, opacity: 0 }}
+      className="p-3 space-y-3"
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onBack}
+        className={BTN_GHOST_ICON}
+        aria-label={t("Retour")}
+      >
+        <ChevronLeft className="w-5 h-5" />
+      </Button>
+      <h1 className={`text-xl font-bold ${T_PRIMARY}`}>
+        {t("Conditions d'utilisation")}
+      </h1>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t("En utilisant cette application, vous acceptez les conditions suivantes.")}
+      </p>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t("L'utilisation doit respecter les lois locales et les réglementations.")}
+      </p>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t("Les auteurs ne peuvent être tenus responsables de l'usage de l'application.")}
+      </p>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t("L'application est fournie en l'état, sans garantie d'aucune sorte.")}
+      </p>
+    </motion.section>
+  );
+}


### PR DESCRIPTION
## Summary
- add terms of use scene and translations
- expose /terms route and link from settings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689992f41e0083298d6a7c2f7e4a0fc3