### PR TITLE
Clarify and manage geolocation consent

### DIFF
--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>La géolocalisation est utilisée pour centrer la carte sur votre position.</string>
+  <key>NSLocationAlwaysUsageDescription</key>
+  <string>La géolocalisation est utilisée pour proposer des zones proches même en arrière-plan.</string>
+</dict>
+</plist>

--- a/src/i18n/settings.ts
+++ b/src/i18n/settings.ts
@@ -18,6 +18,14 @@ export default {
   "clair": { fr: "clair", en: "light" },
   "sombre": { fr: "sombre", en: "dark" },
   "GPS": { fr: "GPS", en: "GPS" },
+  "La géolocalisation est utilisée pour centrer la carte sur votre position.": {
+    fr: "La géolocalisation est utilisée pour centrer la carte sur votre position.",
+    en: "Geolocation is used to center the map on your position.",
+  },
+  "Retirer le consentement": {
+    fr: "Retirer le consentement",
+    en: "Withdraw consent",
+  },
   "Langue": { fr: "Langue", en: "Language" },
   "français": { fr: "français", en: "French" },
   "anglais": { fr: "anglais", en: "English" },

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -23,6 +23,22 @@ export default function SettingsScene({
   const { state, dispatch } = useAppContext();
   const { alerts, prefs } = state;
   const { t } = useT();
+  const handleGpsChange = (v: boolean) => {
+    if (v) {
+      const ok = window.confirm(
+        t(
+          "La géolocalisation est utilisée pour centrer la carte sur votre position."
+        )
+      );
+      if (!ok) return;
+      navigator.geolocation?.getCurrentPosition(() => {}, () => {});
+    }
+    dispatch({ type: "setPrefs", prefs: { gps: v } });
+  };
+  const revokeGps = () => {
+    navigator.permissions?.revoke({ name: "geolocation" as PermissionName });
+    dispatch({ type: "setPrefs", prefs: { gps: false } });
+  };
   return (
     <motion.section
       initial={{ x: 20, opacity: 0 }}
@@ -96,8 +112,11 @@ export default function SettingsScene({
           <ToggleRow
             label={t("GPS")}
             checked={prefs.gps}
-            onChange={(v) => dispatch({ type: "setPrefs", prefs: { gps: v } })}
+            onChange={handleGpsChange}
           />
+          <Button onClick={revokeGps} className={BTN}>
+            {t("Retirer le consentement")}
+          </Button>
           <SelectRow
             label={t("Langue")}
             value={prefs.lang}


### PR DESCRIPTION
## Summary
- explain why location is requested and allow revoking consent in settings
- add translations for geolocation consent strings
- document iOS geolocation usage descriptions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68999495a88c8329aa1093e436c5864c