### PR TITLE
Add detailed terms and privacy policy

### DIFF
--- a/src/i18n/privacy.ts
+++ b/src/i18n/privacy.ts
@@ -3,16 +3,68 @@ export default {
     fr: "Politique de confidentialité",
     en: "Privacy Policy",
   },
-  "Nous ne collectons aucune donnée personnelle. Les informations restent sur votre appareil.": {
-    fr: "Nous ne collectons aucune donnée personnelle. Les informations restent sur votre appareil.",
-    en: "We do not collect any personal data. Information stays on your device.",
+  "1. Collecte des informations": {
+    fr: "1. Collecte des informations",
+    en: "1. Information Collection",
   },
-  "Aucune donnée n'est transmise à des serveurs externes sans votre consentement explicite.": {
-    fr: "Aucune donnée n'est transmise à des serveurs externes sans votre consentement explicite.",
-    en: "No data is sent to external servers without your explicit consent.",
+  "Nous collectons uniquement les informations que vous nous fournissez volontairement via l'application.": {
+    fr: "Nous collectons uniquement les informations que vous nous fournissez volontairement via l'application.",
+    en: "We collect only the information you voluntarily provide through the app.",
   },
-  "L'utilisation de l'application implique l'acceptation de cette politique.": {
-    fr: "L'utilisation de l'application implique l'acceptation de cette politique.",
-    en: "Using the application implies acceptance of this policy.",
+  "2. Utilisation des informations": {
+    fr: "2. Utilisation des informations",
+    en: "2. Use of Information",
+  },
+  "Les informations sont utilisées pour fournir et améliorer le service et ne sont pas utilisées à d'autres fins.": {
+    fr: "Les informations sont utilisées pour fournir et améliorer le service et ne sont pas utilisées à d'autres fins.",
+    en: "Information is used to provide and improve the service and is not used for other purposes.",
+  },
+  "3. Partage des informations": {
+    fr: "3. Partage des informations",
+    en: "3. Information Sharing",
+  },
+  "Nous ne vendons ni ne partageons vos informations personnelles avec des tiers, sauf si la loi l'exige.": {
+    fr: "Nous ne vendons ni ne partageons vos informations personnelles avec des tiers, sauf si la loi l'exige.",
+    en: "We do not sell or share your personal information with third parties except as required by law.",
+  },
+  "4. Conservation des données": {
+    fr: "4. Conservation des données",
+    en: "4. Data Retention",
+  },
+  "Les informations sont conservées uniquement pendant la durée nécessaire pour atteindre l'objectif décrit.": {
+    fr: "Les informations sont conservées uniquement pendant la durée nécessaire pour atteindre l'objectif décrit.",
+    en: "Information is retained only for the time necessary to fulfill the stated purpose.",
+  },
+  "5. Droits des utilisateurs": {
+    fr: "5. Droits des utilisateurs",
+    en: "5. User Rights",
+  },
+  "Vous pouvez demander l'accès, la rectification ou la suppression de vos informations personnelles en nous contactant.": {
+    fr: "Vous pouvez demander l'accès, la rectification ou la suppression de vos informations personnelles en nous contactant.",
+    en: "You may request access to, correction or deletion of your personal information by contacting us.",
+  },
+  "6. Sécurité": {
+    fr: "6. Sécurité",
+    en: "6. Security",
+  },
+  "Nous mettons en place des mesures raisonnables pour protéger vos informations contre tout accès non autorisé.": {
+    fr: "Nous mettons en place des mesures raisonnables pour protéger vos informations contre tout accès non autorisé.",
+    en: "We implement reasonable measures to protect your information from unauthorized access.",
+  },
+  "7. Modifications de la politique": {
+    fr: "7. Modifications de la politique",
+    en: "7. Changes to the Policy",
+  },
+  "Nous pouvons mettre à jour cette politique de confidentialité. Les modifications sont publiées sur cette page.": {
+    fr: "Nous pouvons mettre à jour cette politique de confidentialité. Les modifications sont publiées sur cette page.",
+    en: "We may update this privacy policy. Changes will be posted on this page.",
+  },
+  "8. Contact": {
+    fr: "8. Contact",
+    en: "8. Contact",
+  },
+  "Pour toute question concernant cette politique, contactez-nous à l'adresse contact@example.com.": {
+    fr: "Pour toute question concernant cette politique, contactez-nous à l'adresse contact@example.com.",
+    en: "For any questions about this policy, please contact us at contact@example.com.",
   },
 };

--- a/src/i18n/terms.ts
+++ b/src/i18n/terms.ts
@@ -3,20 +3,56 @@ export default {
     fr: "Conditions d'utilisation",
     en: "Terms of Use",
   },
-  "En utilisant cette application, vous acceptez les conditions suivantes.": {
-    fr: "En utilisant cette application, vous acceptez les conditions suivantes.",
-    en: "By using this application, you agree to the following terms.",
+  "1. Acceptation des conditions": {
+    fr: "1. Acceptation des conditions",
+    en: "1. Acceptance of Terms",
   },
-  "L'utilisation doit respecter les lois locales et les réglementations.": {
-    fr: "L'utilisation doit respecter les lois locales et les réglementations.",
-    en: "Use must comply with local laws and regulations.",
+  "En accédant à et en utilisant cette application, vous acceptez d'être lié par ces conditions d'utilisation.": {
+    fr: "En accédant à et en utilisant cette application, vous acceptez d'être lié par ces conditions d'utilisation.",
+    en: "By accessing and using this application, you agree to be bound by these terms of use.",
   },
-  "Les auteurs ne peuvent être tenus responsables de l'usage de l'application.": {
-    fr: "Les auteurs ne peuvent être tenus responsables de l'usage de l'application.",
-    en: "The authors cannot be held responsible for the use of the application.",
+  "2. Utilisation du service": {
+    fr: "2. Utilisation du service",
+    en: "2. Use of the Service",
   },
-  "L'application est fournie en l'état, sans garantie d'aucune sorte.": {
-    fr: "L'application est fournie en l'état, sans garantie d'aucune sorte.",
-    en: "The application is provided as is, without any warranty.",
+  "Vous acceptez d'utiliser l'application uniquement à des fins légales et conformément aux lois en vigueur.": {
+    fr: "Vous acceptez d'utiliser l'application uniquement à des fins légales et conformément aux lois en vigueur.",
+    en: "You agree to use the application only for lawful purposes and in accordance with applicable laws.",
+  },
+  "Vous vous engagez à ne pas nuire au fonctionnement de l'application.": {
+    fr: "Vous vous engagez à ne pas nuire au fonctionnement de l'application.",
+    en: "You agree not to interfere with the operation of the application.",
+  },
+  "3. Propriété intellectuelle": {
+    fr: "3. Propriété intellectuelle",
+    en: "3. Intellectual Property",
+  },
+  "Le contenu et les fonctionnalités de l'application sont protégés par des droits d'auteur. Vous ne pouvez pas les reproduire sans autorisation.": {
+    fr: "Le contenu et les fonctionnalités de l'application sont protégés par des droits d'auteur. Vous ne pouvez pas les reproduire sans autorisation.",
+    en: "The application's content and features are protected by copyright. You may not reproduce them without permission.",
+  },
+  "4. Limitation de responsabilité": {
+    fr: "4. Limitation de responsabilité",
+    en: "4. Limitation of Liability",
+  },
+  "L'application est fournie en l'état et les développeurs ne peuvent être tenus responsables des dommages résultant de son utilisation.": {
+    fr: "L'application est fournie en l'état et les développeurs ne peuvent être tenus responsables des dommages résultant de son utilisation.",
+    en: "The application is provided as is and the developers cannot be held liable for damages resulting from its use.",
+  },
+  "5. Modifications des conditions": {
+    fr: "5. Modifications des conditions",
+    en: "5. Changes to the Terms",
+  },
+  "Nous nous réservons le droit de modifier ces conditions à tout moment. Les modifications sont publiées sur cette page.": {
+    fr: "Nous nous réservons le droit de modifier ces conditions à tout moment. Les modifications sont publiées sur cette page.",
+    en: "We reserve the right to modify these terms at any time. Changes will be posted on this page.",
+  },
+  "6. Contact": {
+    fr: "6. Contact",
+    en: "6. Contact",
+  },
+  "Pour toute question concernant ces conditions, contactez-nous à l'adresse contact@example.com.": {
+    fr: "Pour toute question concernant ces conditions, contactez-nous à l'adresse contact@example.com.",
+    en: "For any questions regarding these terms, please contact us at contact@example.com.",
   },
 };

--- a/src/scenes/PrivacyPolicyScene.tsx
+++ b/src/scenes/PrivacyPolicyScene.tsx
@@ -24,18 +24,77 @@ export default function PrivacyPolicyScene({ onBack }: { onBack: () => void }) {
         <ChevronLeft className="w-5 h-5" />
       </Button>
       <h1 className={`text-xl font-bold ${T_PRIMARY}`}>{t("Politique de confidentialité")}</h1>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("1. Collecte des informations")}
+      </h2>
       <p className={`text-sm ${T_MUTED}`}>
         {t(
-          "Nous ne collectons aucune donnée personnelle. Les informations restent sur votre appareil."
+          "Nous collectons uniquement les informations que vous nous fournissez volontairement via l'application."
         )}
       </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("2. Utilisation des informations")}
+      </h2>
       <p className={`text-sm ${T_MUTED}`}>
         {t(
-          "Aucune donnée n'est transmise à des serveurs externes sans votre consentement explicite."
+          "Les informations sont utilisées pour fournir et améliorer le service et ne sont pas utilisées à d'autres fins."
         )}
       </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("3. Partage des informations")}
+      </h2>
       <p className={`text-sm ${T_MUTED}`}>
-        {t("L'utilisation de l'application implique l'acceptation de cette politique.")}
+        {t(
+          "Nous ne vendons ni ne partageons vos informations personnelles avec des tiers, sauf si la loi l'exige."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("4. Conservation des données")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Les informations sont conservées uniquement pendant la durée nécessaire pour atteindre l'objectif décrit."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("5. Droits des utilisateurs")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Vous pouvez demander l'accès, la rectification ou la suppression de vos informations personnelles en nous contactant."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("6. Sécurité")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Nous mettons en place des mesures raisonnables pour protéger vos informations contre tout accès non autorisé."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("7. Modifications de la politique")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Nous pouvons mettre à jour cette politique de confidentialité. Les modifications sont publiées sur cette page."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("8. Contact")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Pour toute question concernant cette politique, contactez-nous à l'adresse contact@example.com."
+        )}
       </p>
     </motion.section>
   );

--- a/src/scenes/TermsScene.tsx
+++ b/src/scenes/TermsScene.tsx
@@ -26,17 +26,62 @@ export default function TermsScene({ onBack }: { onBack: () => void }) {
       <h1 className={`text-xl font-bold ${T_PRIMARY}`}>
         {t("Conditions d'utilisation")}
       </h1>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("1. Acceptation des conditions")}
+      </h2>
       <p className={`text-sm ${T_MUTED}`}>
-        {t("En utilisant cette application, vous acceptez les conditions suivantes.")}
+        {t(
+          "En accédant à et en utilisant cette application, vous acceptez d'être lié par ces conditions d'utilisation."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("2. Utilisation du service")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Vous acceptez d'utiliser l'application uniquement à des fins légales et conformément aux lois en vigueur."
+        )}
       </p>
       <p className={`text-sm ${T_MUTED}`}>
-        {t("L'utilisation doit respecter les lois locales et les réglementations.")}
+        {t("Vous vous engagez à ne pas nuire au fonctionnement de l'application.")}
       </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("3. Propriété intellectuelle")}
+      </h2>
       <p className={`text-sm ${T_MUTED}`}>
-        {t("Les auteurs ne peuvent être tenus responsables de l'usage de l'application.")}
+        {t(
+          "Le contenu et les fonctionnalités de l'application sont protégés par des droits d'auteur. Vous ne pouvez pas les reproduire sans autorisation."
+        )}
       </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("4. Limitation de responsabilité")}
+      </h2>
       <p className={`text-sm ${T_MUTED}`}>
-        {t("L'application est fournie en l'état, sans garantie d'aucune sorte.")}
+        {t(
+          "L'application est fournie en l'état et les développeurs ne peuvent être tenus responsables des dommages résultant de son utilisation."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("5. Modifications des conditions")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Nous nous réservons le droit de modifier ces conditions à tout moment. Les modifications sont publiées sur cette page."
+        )}
+      </p>
+
+      <h2 className={`text-lg font-semibold ${T_PRIMARY}`}>
+        {t("6. Contact")}
+      </h2>
+      <p className={`text-sm ${T_MUTED}`}>
+        {t(
+          "Pour toute question concernant ces conditions, contactez-nous à l'adresse contact@example.com."
+        )}
       </p>
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- expand Terms of Use with sections on acceptance, usage, intellectual property, liability, changes, and contact details
- flesh out Privacy Policy covering data collection, use, sharing, retention, user rights, security, updates, and contact
- update Terms and Privacy scenes to render the new detailed content

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899958c18bc8329961444a707e53ef9