### PR TITLE
feat: add color tokens

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -7,8 +7,8 @@ interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 export function Badge({ variant = "default", className = "", ...props }: BadgeProps) {
   const base = "inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium";
   const variants = {
-    default: "border-neutral-300 bg-neutral-200 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100",
-    secondary: "border-neutral-300 bg-neutral-300 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-700 dark:text-neutral-100",
+    default: "border-secondary bg-secondary text-primary dark:border-secondary dark:bg-secondary dark:text-primary",
+    secondary: "border-secondary bg-primary text-secondary dark:border-secondary dark:bg-primary dark:text-secondary",
   } as const;
   return <span className={`${base} ${variants[variant]} ${className}`} {...props} />;
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -8,8 +8,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export function Button({ variant = "default", size = "default", className = "", ...props }: ButtonProps) {
   const base = "inline-flex items-center justify-center rounded-xl text-sm font-medium transition-colors focus:outline-none disabled:opacity-50";
   const variants = {
-    default: "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-600",
-    ghost: "bg-transparent hover:bg-neutral-100 dark:hover:bg-neutral-800",
+    default: "bg-secondary text-primary hover:bg-secondary/80 dark:bg-secondary dark:text-primary dark:hover:bg-secondary/60",
+    ghost: "bg-transparent hover:bg-secondary dark:hover:bg-secondary",
   } as const;
   const sizes = {
     default: "px-3 py-2",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 
 export function Card({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  const base = "rounded-2xl border border-neutral-300 bg-neutral-100 text-neutral-900 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100";
+  const base = "rounded-2xl border border-secondary bg-secondary text-primary dark:border-secondary dark:bg-secondary dark:text-primary";
   return <div className={`${base} ${className}`} {...props} />;
 }
 
 export function CardHeader({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={`p-4 border-b border-neutral-300 dark:border-neutral-800 ${className}`} {...props} />;
+  return <div className={`p-4 border-b border-secondary dark:border-secondary ${className}`} {...props} />;
 }
 
 export function CardTitle({ className = "", ...props }: React.HTMLAttributes<HTMLHeadingElement>) {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export function Input({ className = "", ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
-  const base = "flex h-10 w-full rounded-xl border border-neutral-300 bg-neutral-100 px-3 py-2 text-sm text-neutral-900 focus:outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100";
+  const base = "flex h-10 w-full rounded-xl border border-secondary bg-secondary px-3 py-2 text-sm text-primary focus:outline-none dark:border-secondary dark:bg-secondary dark:text-primary";
   return <input className={`${base} ${className}`} {...props} />;
 }
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,9 +7,9 @@ interface ProgressProps {
 
 export function Progress({ value = 0, className = "" }: ProgressProps) {
   return (
-    <div className={`w-full h-2 rounded-full bg-neutral-200 dark:bg-neutral-800 ${className}`}>
+    <div className={`w-full h-2 rounded-full bg-secondary dark:bg-secondary ${className}`}>
       <div
-        className="h-2 rounded-full bg-neutral-900 dark:bg-neutral-100 transition-all"
+        className="h-2 rounded-full bg-primary dark:bg-primary transition-all"
         style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
       />
     </div>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -13,10 +13,10 @@ export function Switch({ checked = false, onCheckedChange, className = "" }: Swi
       role="switch"
       aria-checked={checked}
       onClick={() => onCheckedChange?.(!checked)}
-      className={`relative inline-flex h-6 w-10 items-center rounded-full border border-neutral-300 bg-neutral-200 transition-colors dark:border-neutral-700 dark:bg-neutral-800 ${checked ? "bg-neutral-700 dark:bg-neutral-300" : ""} ${className}`}
+      className={`relative inline-flex h-6 w-10 items-center rounded-full border border-secondary bg-secondary transition-colors dark:border-secondary dark:bg-secondary ${checked ? "bg-primary dark:bg-primary" : ""} ${className}`}
     >
       <span
-        className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow transform transition-transform dark:bg-neutral-900 ${checked ? "translate-x-4" : "translate-x-0"}`}
+        className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow transform transition-transform dark:bg-primary ${checked ? "translate-x-4" : "translate-x-0"}`}
       />
     </button>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,10 @@
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --border: 214.3 31.8% 91.4%;
+    --primary: 221.2 83.2% 53.3%;
+    --secondary: 210 40% 96.1%;
+    --success: 142.1 76.2% 36.3%;
+    --danger: 0 84.2% 60.2%;
     --radius: 0.5rem;
   }
 

--- a/src/scenes/DownloadScene.tsx
+++ b/src/scenes/DownloadScene.tsx
@@ -24,7 +24,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
         <div className="relative flex-1">
           <Input
             placeholder={t("Rechercher une zone…")}
-            className={`pl-9 bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
+            className={`pl-9 bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
           />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
         </div>
@@ -32,15 +32,15 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
           <ChevronLeft className="w-5 h-5" />
         </Button>
       </div>
-      <div className="relative h-[50vh] rounded-2xl border border-neutral-300 dark:border-neutral-800 overflow-hidden bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)] bg-neutral-100 dark:bg-neutral-900">
+      <div className="relative h-[50vh] rounded-2xl border border-secondary dark:border-secondary overflow-hidden bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)] bg-secondary dark:bg-secondary">
         <div className="absolute inset-6 border-2 border-red-600 rounded-xl" />
-        <div className={`absolute top-3 left-3 bg-neutral-100/80 dark:bg-neutral-900/80 rounded-xl px-3 py-1 text-sm ${T_PRIMARY}`}>
+        <div className={`absolute top-3 left-3 bg-secondary/80 dark:bg-secondary/80 rounded-xl px-3 py-1 text-sm ${T_PRIMARY}`}>
           {t("Vue actuelle")}
         </div>
       </div>
 
       <div className="mt-3 grid md:grid-cols-2 gap-3">
-        <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
+        <Card className="bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl">
           <CardContent className="pt-4 space-y-2">
             <Row label={t("Taille estimée")} value={`${packSize} Mo`} />
             <Row label={t("Espace disponible")} value={`${deviceFree} Mo`} />
@@ -59,7 +59,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
                   <Download className="w-4 h-4 mr-2" />
                   {t("Télécharger")}
                 </Button>
-                <Button variant="ghost" onClick={onCancel} className={`flex-1 rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}>
+                <Button variant="ghost" onClick={onCancel} className={`flex-1 rounded-xl hover:bg-secondary dark:hover:bg-secondary ${T_PRIMARY}`}>
                   {t("Annuler")}
                 </Button>
               </div>
@@ -72,7 +72,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
           </CardContent>
         </Card>
 
-        <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
+        <Card className="bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl">
           <CardHeader>
             <CardTitle className={T_PRIMARY}>{t("États possibles")}</CardTitle>
           </CardHeader>

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -29,7 +29,7 @@ export default function LandingScene({ onSeeMap, onMySpots, onOpenSettings, onOp
       />
       <div className="absolute inset-0 bg-black/60" />
       <div className="relative z-10 max-w-3xl mx-auto px-6 py-20 text-center">
-        <div className="mx-auto mb-6 w-20 h-20 rounded-2xl bg-neutral-200/60 dark:bg-neutral-800/60 border border-neutral-300 dark:border-neutral-700 grid place-items-center shadow-xl">
+        <div className="mx-auto mb-6 w-20 h-20 rounded-2xl bg-secondary/60 dark:bg-secondary/60 border border-secondary dark:border-secondary grid place-items-center shadow-xl">
           <MushroomIcon className={T_PRIMARY} />
         </div>
         <h1 className={`text-3xl font-semibold ${T_PRIMARY}`}>

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -84,7 +84,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
         <div className="relative flex-1">
           <Input
             placeholder={t("Rechercher un lieu…")}
-            className={`pl-9 bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
+            className={`pl-9 bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
           />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
         </div>
@@ -94,7 +94,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
         </Button>
       </div>
 
-      <div className="relative h-[60vh] rounded-2xl border border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 overflow-hidden">
+      <div className="relative h-[60vh] rounded-2xl border border-secondary dark:border-secondary bg-secondary dark:bg-secondary overflow-hidden">
         <div ref={mapContainer} className="absolute inset-0 w-full h-full" />
 
         {gpsFollow && (
@@ -108,7 +108,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
             <Navigation className="w-4 h-4" />
           </Button>
         )}
-        <div className="absolute top-3 left-3 bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur rounded-xl p-2 border border-neutral-300 dark:border-neutral-800 flex items-center gap-2">
+        <div className="absolute top-3 left-3 bg-secondary/80 dark:bg-secondary/80 backdrop-blur rounded-xl p-2 border border-secondary dark:border-secondary flex items-center gap-2">
           <span className={`text-xs ${T_PRIMARY}`}>{t("Légende")}</span>
           {LEGEND.map((l, i) => (
             <div key={i} className="flex items-center gap-1">
@@ -125,7 +125,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
               onClick={() => onZone(z)}
               role="button"
               tabIndex={0}
-              className="bg-neutral-100/80 hover:bg-neutral-200/80 dark:bg-neutral-900/80 dark:hover:bg-neutral-800/80 border border-neutral-300 dark:border-neutral-800 rounded-xl px-3 py-2 text-left cursor-pointer"
+              className="bg-secondary/80 hover:bg-secondary/80 dark:bg-secondary/80 dark:hover:bg-secondary/80 border border-secondary dark:border-secondary rounded-xl px-3 py-2 text-left cursor-pointer"
             >
               <div className="flex items-center justify-between">
                 <div className={`font-medium ${T_PRIMARY}`}>{z.name}</div>
@@ -134,14 +134,14 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
               <div className={`text-xs ${T_MUTED}`}>{t(z.trend)}</div>
               <div className="mt-1 flex gap-1">
                 {Object.entries(z.species).map(([id, sc]) => (
-                  <span key={id} onClick={(e) => { e.stopPropagation(); onOpenShroom(id); }} className={`text-[10px] bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 dark:bg-neutral-800 dark:border-neutral-700 dark:hover:bg-neutral-700 px-2 py-1 rounded-full ${T_PRIMARY} cursor-pointer`}>{MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0]} {sc}%</span>
+                  <span key={id} onClick={(e) => { e.stopPropagation(); onOpenShroom(id); }} className={`text-[10px] bg-secondary border border-secondary hover:bg-secondary dark:bg-secondary dark:border-secondary dark:hover:bg-secondary px-2 py-1 rounded-full ${T_PRIMARY} cursor-pointer`}>{MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0]} {sc}%</span>
                 ))}
               </div>
             </div>
           ))}
         </div>
 
-        <div className="absolute bottom-3 right-3 bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur rounded-xl p-2 border border-neutral-300 dark:border-neutral-800">
+        <div className="absolute bottom-3 right-3 bg-secondary/80 dark:bg-secondary/80 backdrop-blur rounded-xl p-2 border border-secondary dark:border-secondary">
           <input type="range" min={1} max={14} value={zoom} onChange={(e) => setZoom(parseInt(e.target.value, 10))} />
         </div>
       </div>

--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -22,7 +22,7 @@ export default function MushroomScene({ item, onSeeZones, onBack }: { item: Mush
       >
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <div className="rounded-2xl overflow-hidden border border-neutral-300 dark:border-neutral-800">
+      <div className="rounded-2xl overflow-hidden border border-secondary dark:border-secondary">
         <img src={item.photo} className="w-full h-60 object-cover" />
       </div>
 

--- a/src/scenes/PickerScene.tsx
+++ b/src/scenes/PickerScene.tsx
@@ -21,15 +21,15 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t("Rechercher un champignon…")}
-          className={`bg-neutral-100 border-neutral-300 dark:bg-neutral-900 dark:border-neutral-800 ${T_PRIMARY}`}
+          className={`bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
         />
-        <select value={seasonFilter} onChange={(e) => setSeasonFilter(e.target.value)} className="bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm">
+        <select value={seasonFilter} onChange={(e) => setSeasonFilter(e.target.value)} className="bg-secondary border border-secondary text-primary dark:bg-secondary dark:border-secondary dark:text-primary rounded-xl px-3 py-2 text-sm">
           <option value="toutes">{t("Toutes saisons")}</option>
           <option>{t("Printemps")}</option>
           <option>{t("Été")}</option>
           <option>{t("Automne")}</option>
         </select>
-        <select value={valueFilter} onChange={(e) => setValueFilter(e.target.value)} className="bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm">
+        <select value={valueFilter} onChange={(e) => setValueFilter(e.target.value)} className="bg-secondary border border-secondary text-primary dark:bg-secondary dark:border-secondary dark:text-primary rounded-xl px-3 py-2 text-sm">
           <option value="toutes">{t("Toute valeur")}</option>
           <option>{t("Excellente")}</option>
           <option>{t("Bonne")}</option>
@@ -39,7 +39,7 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
 
       <div className="grid md:grid-cols-3 gap-3">
         {items.map(m => (
-          <button key={m.id} onClick={() => onPick(m)} className="text-left bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl overflow-hidden hover:border-neutral-400 dark:hover:border-neutral-700">
+          <button key={m.id} onClick={() => onPick(m)} className="text-left bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl overflow-hidden hover:border-secondary dark:hover:border-secondary">
             <img src={m.photo} className="w-full h-40 object-cover" />
             <div className="p-3">
               <div className={`font-medium ${T_PRIMARY}`}>{m.name}</div>

--- a/src/scenes/RouteScene.tsx
+++ b/src/scenes/RouteScene.tsx
@@ -12,7 +12,7 @@ export default function RouteScene({ onBackToMap, onBack }: { onBackToMap: () =>
       <Button variant="ghost" size="icon" onClick={onBack} className={`${BTN_GHOST_ICON} mb-3`} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <div className="relative h-[60vh] rounded-2xl border border-neutral-300 dark:border-neutral-800 overflow-hidden bg-neutral-100 dark:bg-neutral-900 grid">
+      <div className="relative h-[60vh] rounded-2xl border border-secondary dark:border-secondary overflow-hidden bg-secondary dark:bg-secondary grid">
         <div className={`p-3 text-sm ${T_MUTED}`}>
           {t("Instructions étape par étape (démo) :")}
           <br />🚗 {t("Rejoindre parking")} → 🚶 {t("Sentier balisé")} → 🧭 {t("Boussole sur 250 m")}

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -49,7 +49,7 @@ export default function SettingsScene({
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
+      <Card className="bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl">
         <CardHeader>
           <CardTitle className={T_PRIMARY}>{t("Cartes hors‑ligne")}</CardTitle>
         </CardHeader>
@@ -67,7 +67,7 @@ export default function SettingsScene({
         </CardContent>
       </Card>
 
-      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
+      <Card className="bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl">
         <CardHeader>
           <CardTitle className={T_PRIMARY}>{t("Alertes")}</CardTitle>
         </CardHeader>
@@ -85,7 +85,7 @@ export default function SettingsScene({
         </CardContent>
       </Card>
 
-      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
+      <Card className="bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl">
         <CardHeader>
           <CardTitle className={T_PRIMARY}>{t("Préférences")}</CardTitle>
         </CardHeader>

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -48,16 +48,16 @@ export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; o
       <div className="grid md:grid-cols-2 gap-3">
         {spots.length === 0 && <div className={T_PRIMARY}>{t("Aucun coin enregistré.")}</div>}
         {spots.map(s => (
-          <Card key={s.id} className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl overflow-hidden relative">
+          <Card key={s.id} className="bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl overflow-hidden relative">
             <button onClick={() => setDetails(s)} className="block text-left">
               <img src={s.cover || s.photos?.[0]} className="w-full h-40 object-cover" />
             </button>
             <button
               onClick={() => setEditing(s)}
-              className="absolute top-2 right-2 bg-neutral-100/80 hover:bg-neutral-200/80 dark:bg-neutral-900/80 dark:hover:bg-neutral-800/80 border border-neutral-300 dark:border-neutral-700 rounded-full p-2"
+              className="absolute top-2 right-2 bg-secondary/80 hover:bg-secondary/80 dark:bg-secondary/80 dark:hover:bg-secondary/80 border border-secondary dark:border-secondary rounded-full p-2"
               aria-label={t("modifier")}
             >
-              <Pencil className="w-4 h-4 text-neutral-200" />
+              <Pencil className="w-4 h-4 text-secondary" />
             </button>
             <CardContent className="p-4">
               <div className="flex items-center justify-between">

--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -29,7 +29,7 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
       >
         <ChevronLeft className="w-5 h-5" />
       </Button>
-      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
+      <Card className="bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl">
         <CardHeader>
           <CardTitle className={`flex items-center justify-between ${T_PRIMARY}`}>
             <div>
@@ -59,7 +59,7 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
               {Object.entries(zone.species as Record<string, number>).filter(([_, v]) => v > 0).map(([id, sc]) => {
                 const m = MUSHROOMS.find(m => m.id === id);
                 return (
-                  <button key={id} onClick={() => onOpenShroom(id)} className={`bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 dark:bg-neutral-800 dark:border-neutral-700 dark:hover:bg-neutral-700 rounded-xl p-2 ${T_PRIMARY}`}>
+                  <button key={id} onClick={() => onOpenShroom(id)} className={`bg-secondary border border-secondary hover:bg-secondary dark:bg-secondary dark:border-secondary dark:hover:bg-secondary rounded-xl p-2 ${T_PRIMARY}`}>
                     <div className="flex items-center gap-2">
                       <img src={m.photo} className="w-12 h-12 object-cover rounded-lg" />
                       <div>

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,7 +1,7 @@
 export const BTN =
-  "rounded-xl bg-neutral-200 text-neutral-900 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-600";
+  "rounded-xl bg-secondary text-primary hover:bg-secondary/80";
 export const BTN_GHOST_ICON =
-  "text-neutral-900 hover:bg-neutral-200 dark:text-neutral-300 dark:hover:bg-neutral-800";
-export const T_PRIMARY = "text-neutral-900 dark:text-neutral-100";
-export const T_MUTED = "text-neutral-600 dark:text-neutral-300";
-export const T_SUBTLE = "text-neutral-500 dark:text-neutral-400";
+  "text-primary hover:bg-secondary";
+export const T_PRIMARY = "text-primary";
+export const T_MUTED = "text-secondary";
+export const T_SUBTLE = "text-secondary/80";

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,6 +8,10 @@ module.exports = {
         border: "hsl(var(--border))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        primary: "hsl(var(--primary))",
+        secondary: "hsl(var(--secondary))",
+        success: "hsl(var(--success))",
+        danger: "hsl(var(--danger))",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- add primary, secondary, success, and danger colors to Tailwind config
- expose new colors as CSS variables and tokens
- switch UI components and scenes from neutral palette to primary/secondary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68999b69231c8329808da76d75e20b93