### PR TITLE
Move authentication and premium upgrades to settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,9 +132,6 @@ function AppContent() {
                   onMySpots={() => goTo(Scene.Spots)}
                   onOpenSettings={() => goTo(Scene.Settings)}
                   onOpenPicker={() => goTo(Scene.Picker)}
-                  onLogin={() => goTo(Scene.Login)}
-                  onSignup={() => goTo(Scene.Signup)}
-                  onPremium={() => goTo(Scene.Premium)}
                 />
               }
             />
@@ -226,6 +223,9 @@ function AppContent() {
                   onOpenPacks={() => goTo(Scene.Download)}
                   onOpenPrivacy={() => goTo(Scene.Privacy)}
                   onOpenTerms={() => goTo(Scene.Terms)}
+                  onLogin={() => goTo(Scene.Login)}
+                  onSignup={() => goTo(Scene.Signup)}
+                  onPremium={() => goTo(Scene.Premium)}
                   onBack={goBack}
                 />
               }

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -5,27 +5,19 @@ import { Button } from "@/components/ui/button";
 import { MushroomIcon } from "../components/MushroomIcon";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
 import { useT } from "../i18n";
-import { useAuth } from "../context/AuthContext";
 
 export default function LandingScene({
   onSeeMap,
   onMySpots,
   onOpenSettings,
   onOpenPicker,
-  onLogin,
-  onSignup,
-  onPremium,
 }: {
   onSeeMap: () => void;
   onMySpots: () => void;
   onOpenSettings: () => void;
   onOpenPicker: () => void;
-  onLogin: () => void;
-  onSignup: () => void;
-  onPremium: () => void;
 }) {
   const { t } = useT();
-  const { user } = useAuth();
   return (
     <motion.section initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="relative min-h-[calc(100vh-0px)]">
       <div className="absolute top-3 right-3 z-20">
@@ -64,22 +56,6 @@ export default function LandingScene({
             {t("Les champignons")}
           </Button>
         </div>
-        {!user ? (
-          <div className="mt-3 flex items-center justify-center gap-3">
-            <Button onClick={onLogin} className={BTN}>
-              {t("Se connecter")}
-            </Button>
-            <Button onClick={onSignup} className={BTN}>
-              {t("Créer un compte")}
-            </Button>
-          </div>
-        ) : (
-          <div className="mt-3 flex justify-center">
-            <Button onClick={onPremium} className={BTN}>
-              {user.premium ? t("Compte premium") : t("Passer en premium")}
-            </Button>
-          </div>
-        )}
         <p className={`mt-8 text-sm ${T_MUTED}`}>
           {t("Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.")}
         </p>

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -7,6 +7,7 @@ import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
 import { ToggleRow } from "../components/ToggleRow";
 import { SelectRow } from "../components/SelectRow";
 import { useAppContext } from "../context/AppContext";
+import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
 
 export default function SettingsScene({
@@ -14,14 +15,21 @@ export default function SettingsScene({
   onOpenPrivacy,
   onOpenTerms,
   onBack,
+  onLogin,
+  onSignup,
+  onPremium,
 }: {
   onOpenPacks: () => void;
   onOpenPrivacy: () => void;
   onOpenTerms: () => void;
   onBack: () => void;
+  onLogin: () => void;
+  onSignup: () => void;
+  onPremium: () => void;
 }) {
   const { state, dispatch } = useAppContext();
   const { alerts, prefs } = state;
+  const { user, logout } = useAuth();
   const { t } = useT();
   const handleGpsChange = (v: boolean) => {
     if (v) {
@@ -49,6 +57,37 @@ export default function SettingsScene({
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>
+      <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
+        <CardHeader>
+          <CardTitle className={T_PRIMARY}>{t("Compte")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {user ? (
+            <div className="space-y-2">
+              <div className={`font-medium ${T_PRIMARY}`}>{user.username}</div>
+              {!user.premium ? (
+                <Button onClick={onPremium} className={BTN}>
+                  {t("Passer en premium")}
+                </Button>
+              ) : (
+                <div className={`text-sm ${T_MUTED}`}>{t("Compte premium")}</div>
+              )}
+              <Button onClick={logout} className={BTN}>
+                {t("Se déconnecter")}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <Button onClick={onLogin} className={BTN}>
+                {t("Se connecter")}
+              </Button>
+              <Button onClick={onSignup} className={BTN}>
+                {t("Créer un compte")}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
       <Card className="bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl">
         <CardHeader>
           <CardTitle className={T_PRIMARY}>{t("Cartes hors‑ligne")}</CardTitle>


### PR DESCRIPTION
## Summary
- remove login and premium buttons from landing page
- add account management card in settings for login, sign up, premium upgrade and logout
- route auth flows through settings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68999cf14b94832984aecd3394727ce3