### PR TITLE
feat: modernize ui design

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mushroom Finder</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -7,8 +7,10 @@ interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 export function Badge({ variant = "default", className = "", ...props }: BadgeProps) {
   const base = "inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium";
   const variants = {
-    default: "border-secondary bg-secondary text-primary dark:border-secondary dark:bg-secondary dark:text-primary",
-    secondary: "border-secondary bg-primary text-secondary dark:border-secondary dark:bg-primary dark:text-secondary",
+    default:
+      "border-border bg-secondary text-foreground dark:border-border dark:bg-secondary dark:text-foreground",
+    secondary:
+      "border-border bg-primary text-white dark:border-border dark:bg-primary dark:text-white",
   } as const;
   return <span className={`${base} ${variants[variant]} ${className}`} {...props} />;
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -8,8 +8,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export function Button({ variant = "default", size = "default", className = "", ...props }: ButtonProps) {
   const base = "inline-flex items-center justify-center rounded-xl text-sm font-medium transition-colors focus:outline-none disabled:opacity-50";
   const variants = {
-    default: "bg-secondary text-primary hover:bg-secondary/80 dark:bg-secondary dark:text-primary dark:hover:bg-secondary/60",
-    ghost: "bg-transparent hover:bg-secondary dark:hover:bg-secondary",
+    default: "bg-primary text-white hover:bg-primary/90 dark:bg-primary dark:text-white dark:hover:bg-primary/80",
+    ghost: "bg-transparent text-primary hover:bg-primary/10 dark:text-primary dark:hover:bg-primary/20",
   } as const;
   const sizes = {
     default: "px-3 py-2",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 
 export function Card({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  const base = "rounded-2xl border border-secondary bg-secondary text-primary dark:border-secondary dark:bg-secondary dark:text-primary";
+  const base =
+    "rounded-2xl border border-border bg-secondary text-foreground dark:border-border dark:bg-secondary dark:text-foreground";
   return <div className={`${base} ${className}`} {...props} />;
 }
 
 export function CardHeader({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={`p-4 border-b border-secondary dark:border-secondary ${className}`} {...props} />;
+  return <div className={`p-4 border-b border-border dark:border-border ${className}`} {...props} />;
 }
 
 export function CardTitle({ className = "", ...props }: React.HTMLAttributes<HTMLHeadingElement>) {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 export function Input({ className = "", ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
-  const base = "flex h-10 w-full rounded-xl border border-secondary bg-secondary px-3 py-2 text-sm text-primary focus:outline-none dark:border-secondary dark:bg-secondary dark:text-primary";
+  const base =
+    "flex h-10 w-full rounded-xl border border-border bg-secondary px-3 py-2 text-sm text-foreground focus:outline-none dark:border-border dark:bg-secondary dark:text-foreground";
   return <input className={`${base} ${className}`} {...props} />;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,23 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --border: 214.3 31.8% 91.4%;
-    --primary: 221.2 83.2% 53.3%;
-    --secondary: 210 40% 96.1%;
+    --foreground: 240 10% 3.9%;
+    --border: 240 5% 84%;
+    --primary: 142 72% 29%;
+    --secondary: 96 30% 96%;
     --success: 142.1 76.2% 36.3%;
     --danger: 0 84.2% 60.2%;
     --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --border: 240 3% 20%;
+    --primary: 142 62% 45%;
+    --secondary: 142 25% 20%;
+    --success: 142.1 76.2% 36.3%;
+    --danger: 0 84.2% 60.2%;
   }
 
   * {
@@ -18,6 +28,6 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,7 +1,7 @@
 export const BTN =
-  "rounded-xl bg-secondary text-primary hover:bg-secondary/80";
+  "rounded-xl bg-primary text-white hover:bg-primary/90";
 export const BTN_GHOST_ICON =
-  "text-primary hover:bg-secondary";
+  "text-primary hover:bg-primary/10";
 export const T_PRIMARY = "text-primary";
-export const T_MUTED = "text-secondary";
-export const T_SUBTLE = "text-secondary/80";
+export const T_MUTED = "text-foreground/70";
+export const T_SUBTLE = "text-foreground/50";

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -13,6 +13,9 @@ module.exports = {
         success: "hsl(var(--success))",
         danger: "hsl(var(--danger))",
       },
+      fontFamily: {
+        sans: ["Inter", "sans-serif"],
+      },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",


### PR DESCRIPTION
## Summary
- add Inter font and declare as global sans
- introduce earthy green palette with dark mode variables
- refresh button, card, badge and input styles

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68999eb60eb8832992bceb9fa02440ba