### PR TITLE
feat: add grainy art direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       crossorigin
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/public/noise.svg
+++ b/public/noise.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <filter id="n" x="0" y="0" width="100%" height="100%">
+    <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="4"/>
+  </filter>
+  <rect width="100%" height="100%" filter="url(#n)"/>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -29,5 +29,17 @@
 
   body {
     @apply bg-background text-foreground font-sans;
+    background-image: radial-gradient(circle at top left, hsl(var(--primary) / 0.15), transparent),
+      radial-gradient(circle at bottom right, hsl(var(--secondary) / 0.15), transparent);
+  }
+
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("/noise.svg");
+    opacity: 0.08;
+    mix-blend-mode: overlay;
   }
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,7 +14,7 @@ module.exports = {
         danger: "hsl(var(--danger))",
       },
       fontFamily: {
-        sans: ["Inter", "sans-serif"],
+        sans: ["'Space Grotesk'", "sans-serif"],
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- replace typography with Space Grotesk for a modern look
- add grainy overlay and radial gradients for a Behance-style feel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b7e6d12c8329aba58b8d8b110a83