### PR TITLE
Replace mushroom emoji with logo

### DIFF
--- a/src/i18n/landing.ts
+++ b/src/i18n/landing.ts
@@ -1,5 +1,6 @@
 export default {
   "forêt brumeuse": { fr: "forêt brumeuse", en: "misty forest" },
+  "Logo": { fr: "Logo", en: "Logo" },
   "Trouvez vos coins à champignons comestibles, même sans réseau.": {
     fr: "Trouvez vos coins à champignons comestibles, même sans réseau.",
     en: "Find your edible mushroom spots, even offline.",

--- a/src/images.d.ts
+++ b/src/images.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const value: string;
+  export default value;
+}

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -4,6 +4,7 @@ import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BTN, BTN_GHOST_ICON, T_MUTED } from "../styles/tokens";
 import { useT } from "../i18n";
+import logo from "../../Logo.png";
 
 export default function LandingScene({
   onSeeMap,
@@ -56,7 +57,11 @@ export default function LandingScene({
           transition={{ delay: 0.2 }}
           className="max-w-xl p-10 rounded-3xl bg-background/60 backdrop-blur-xl border border-border/50 shadow-2xl"
         >
-          <div className="mx-auto mb-8 w-28 h-28 rounded-[2rem] bg-forest/20 shadow-lg" />
+          <img
+            src={logo}
+            alt={t("Logo")}
+            className="mx-auto mb-8 w-28 h-28 rounded-[2rem] shadow-lg"
+          />
           <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight bg-gradient-to-r from-forest via-moss to-fern bg-clip-text text-transparent">
             {t("Trouvez vos coins à champignons comestibles, même sans réseau.")}
           </h1>


### PR DESCRIPTION
## Summary
- display project logo on landing scene
- add translation for logo alt text
- declare PNG module for TypeScript

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d6187874832989ef8a73c6c93bab