### PR TITLE
feat: add premium upgrade flow

### DIFF
--- a/src/scenes/PremiumScene.tsx
+++ b/src/scenes/PremiumScene.tsx
@@ -23,7 +23,13 @@ export default function PremiumScene({ onBack }: { onBack: () => void }) {
         {user?.premium ? t("Vous êtes premium") : t("Passez en premium pour plus de fonctionnalités")}
       </div>
       {!user?.premium && (
-        <Button onClick={() => { upgrade(); onBack(); }} className={BTN}>
+        <Button
+          onClick={() => {
+            upgrade();
+            onBack();
+          }}
+          className={`${BTN} bg-gold text-foreground hover:bg-gold/90`}
+        >
           {t("Passer en premium")}
         </Button>
       )}

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -31,6 +31,14 @@ export default function SettingsScene({
   const { alerts, prefs } = state;
   const { user, logout } = useAuth();
   const { t } = useT();
+  const handlePremium = () => {
+    if (user) {
+      onPremium();
+    } else {
+      localStorage.setItem("goPremiumAfterSignup", "true");
+      onSignup();
+    }
+  };
   const handleGpsChange = (v: boolean) => {
     if (v) {
       const ok = window.confirm(
@@ -66,7 +74,10 @@ export default function SettingsScene({
             <div className="space-y-2">
               <div className={`font-medium ${T_PRIMARY}`}>{user.username}</div>
               {!user.premium ? (
-                <Button onClick={onPremium} className={BTN}>
+                <Button
+                  onClick={handlePremium}
+                  className={`${BTN} bg-gold text-foreground hover:bg-gold/90`}
+                >
                   {t("Passer en premium")}
                 </Button>
               ) : (
@@ -77,13 +88,21 @@ export default function SettingsScene({
               </Button>
             </div>
           ) : (
-            <div className="flex items-center justify-between">
-              <Button onClick={onLogin} className={BTN}>
-                {t("Se connecter")}
+            <div className="space-y-2">
+              <Button
+                onClick={handlePremium}
+                className={`${BTN} bg-gold text-foreground hover:bg-gold/90`}
+              >
+                {t("Passer en premium")}
               </Button>
-              <Button onClick={onSignup} className={BTN}>
-                {t("Créer un compte")}
-              </Button>
+              <div className="flex items-center justify-between">
+                <Button onClick={onLogin} className={BTN}>
+                  {t("Se connecter")}
+                </Button>
+                <Button onClick={onSignup} className={BTN}>
+                  {t("Créer un compte")}
+                </Button>
+              </div>
             </div>
           )}
         </CardContent>

--- a/src/scenes/SignupScene.tsx
+++ b/src/scenes/SignupScene.tsx
@@ -6,16 +6,24 @@ import { Input } from "@/components/ui/input";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY } from "../styles/tokens";
 import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
+import { useNavigate } from "react-router-dom";
+import { Scene } from "../routes";
 
 export default function SignupScene({ onLogin, onBack }: { onLogin: () => void; onBack: () => void }) {
   const { signup } = useAuth();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const { t } = useT();
+  const navigate = useNavigate();
 
   const handleSignup = () => {
     if (signup(username, password)) {
-      onBack();
+      if (localStorage.getItem("goPremiumAfterSignup") === "true") {
+        localStorage.removeItem("goPremiumAfterSignup");
+        navigate(Scene.Premium);
+      } else {
+        onBack();
+      }
     } else {
       alert(t("Nom d'utilisateur déjà pris"));
     }


### PR DESCRIPTION
## Summary
- add golden Premium button in settings
- redirect signups to premium checkout
- style premium scene action in gold

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d7351d288329935c1c451fdcbed6