### PR TITLE
feat: restore landing tagline

### DIFF
--- a/src/i18n/landing.ts
+++ b/src/i18n/landing.ts
@@ -1,8 +1,8 @@
 export default {
   "forêt brumeuse": { fr: "forêt brumeuse", en: "misty forest" },
   "Logo": { fr: "Logo", en: "Logo" },
-  "Trouvez vos coins à champignons comestibles, même sans réseau.": {
-    fr: "Trouvez vos coins à champignons comestibles, même sans réseau.",
+  "Trouvez vos coins à champignons comestibles, même sans réseaux.": {
+    fr: "Trouvez vos coins à champignons comestibles, même sans réseaux.",
     en: "Find your edible mushroom spots, even offline.",
   },
   "Voir la carte": { fr: "Voir la carte", en: "See map" },

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -63,7 +63,7 @@ export default function LandingScene({
             className="mx-auto mb-8 w-28 h-28 rounded-[2rem] shadow-lg"
           />
           <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight bg-gradient-to-r from-forest via-moss to-fern bg-clip-text text-transparent">
-            {t("Trouvez vos coins à champignons comestibles, même sans réseau.")}
+            {t("Trouvez vos coins à champignons comestibles, même sans réseaux.")}
           </h1>
           <p className={`mt-6 text-lg ${T_MUTED}`}>
             {t("Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.")}


### PR DESCRIPTION
## Summary
- restore landing page tagline under the logo
- update translations for tagline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d86ddbd083299cb1e9596837609a