### PR TITLE
Apply consistent page styling across scenes

### DIFF
--- a/src/scenes/DownloadScene.tsx
+++ b/src/scenes/DownloadScene.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Progress } from "@/components/ui/progress";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE, PAGE } from "../styles/tokens";
 import { Row } from "../components/Row";
 import { useT } from "../i18n";
 
@@ -19,7 +19,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
   }, [includeRelief, includeWeather, setPackSize]);
 
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
+    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className={`p-3 ${PAGE}`}>
       <div className="flex items-center gap-2 mb-3">
         <div className="relative flex-1">
           <Input

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { BTN, BTN_GHOST_ICON, T_MUTED } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_MUTED, PAGE } from "../styles/tokens";
 import { useT } from "../i18n";
 import logo from "../../Logo.png";
 
@@ -23,7 +23,7 @@ export default function LandingScene({
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
-      className="relative min-h-screen overflow-hidden bg-background text-foreground"
+      className={`relative overflow-hidden ${PAGE}`}
     >
       <div className="absolute top-3 right-3 z-20">
         <Button

--- a/src/scenes/LoginScene.tsx
+++ b/src/scenes/LoginScene.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, PAGE } from "../styles/tokens";
 import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
 
@@ -26,7 +26,7 @@ export default function LoginScene({ onSignup, onBack }: { onSignup: () => void;
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-4"
+      className={`p-3 space-y-4 ${PAGE}`}
     >
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -8,7 +8,7 @@ import { MUSHROOMS } from "../data/mushrooms";
 import { DEMO_ZONES } from "../data/zones";
 import { LEGEND } from "../data/legend";
 import { classNames } from "../utils";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE, PAGE } from "../styles/tokens";
 import { loadMapKit } from "@/services/mapkit";
 import { useT } from "../i18n";
 import type { Zone } from "../types";
@@ -71,7 +71,7 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
   const zones = useMemo<Zone[]>(() => (selectedSpecies.length === 0 ? DEMO_ZONES : DEMO_ZONES.filter(z => selectedSpecies.every(id => (z.species[id] || 0) > 50))), [selectedSpecies]);
 
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
+    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className={`p-3 ${PAGE}`}>
       <div className="flex items-center gap-2 mb-3">
         <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />

--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, Calendar, Trees, CloudSun, Info, ChefHat, Sandwich, AlertT
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { InfoBlock } from "../components/InfoBlock";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_SUBTLE } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_SUBTLE, PAGE } from "../styles/tokens";
 import { useT } from "../i18n";
 import type { Mushroom } from "../types";
 
@@ -12,7 +12,7 @@ export default function MushroomScene({ item, onSeeZones, onBack }: { item: Mush
   const { t } = useT();
   if (!item) return <div className={`p-6 ${T_PRIMARY}`}>{t("Sélectionnez un champignon…")}</div>;
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
+    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className={`p-3 ${PAGE}`}>
       <Button
         variant="ghost"
         size="icon"

--- a/src/scenes/PickerScene.tsx
+++ b/src/scenes/PickerScene.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE, PAGE } from "../styles/tokens";
 import { useT } from "../i18n";
 import type { Mushroom } from "../types";
 
@@ -12,7 +12,7 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
   const [valueFilter, setValueFilter] = useState("toutes");
   const { t } = useT();
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
+    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className={`p-3 ${PAGE}`}>
       <div className="grid md:grid-cols-4 gap-2 mb-3 items-center">
         <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />

--- a/src/scenes/PremiumScene.tsx
+++ b/src/scenes/PremiumScene.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, PAGE } from "../styles/tokens";
 import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
 
@@ -14,7 +14,7 @@ export default function PremiumScene({ onBack }: { onBack: () => void }) {
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-4"
+      className={`p-3 space-y-4 ${PAGE}`}
     >
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />

--- a/src/scenes/PrivacyPolicyScene.tsx
+++ b/src/scenes/PrivacyPolicyScene.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
+import { BTN_GHOST_ICON, T_PRIMARY, T_MUTED, PAGE } from "../styles/tokens";
 import { useT } from "../i18n";
 
 export default function PrivacyPolicyScene({ onBack }: { onBack: () => void }) {
@@ -12,7 +12,7 @@ export default function PrivacyPolicyScene({ onBack }: { onBack: () => void }) {
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-3"
+      className={`p-3 space-y-3 ${PAGE}`}
     >
       <Button
         variant="ghost"

--- a/src/scenes/RouteScene.tsx
+++ b/src/scenes/RouteScene.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { BTN, BTN_GHOST_ICON, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_MUTED, T_SUBTLE, PAGE } from "../styles/tokens";
 import { useT } from "../i18n";
 
 export default function RouteScene({ onBackToMap, onBack }: { onBackToMap: () => void; onBack: () => void }) {
   const { t } = useT();
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
+    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className={`p-3 ${PAGE}`}>
       <Button variant="ghost" size="icon" onClick={onBack} className={`${BTN_GHOST_ICON} mb-3`} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />
       </Button>

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import { ChevronLeft, Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, PAGE } from "../styles/tokens";
 import { ToggleRow } from "../components/ToggleRow";
 import { SelectRow } from "../components/SelectRow";
 import { useAppContext } from "../context/AppContext";
@@ -60,7 +60,7 @@ export default function SettingsScene({
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-3"
+      className={`p-3 space-y-3 ${PAGE}`}
     >
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />

--- a/src/scenes/SignupScene.tsx
+++ b/src/scenes/SignupScene.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, PAGE } from "../styles/tokens";
 import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
 import { useNavigate } from "react-router-dom";
@@ -34,7 +34,7 @@ export default function SignupScene({ onLogin, onBack }: { onLogin: () => void; 
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-4"
+      className={`p-3 space-y-4 ${PAGE}`}
     >
       <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
         <ChevronLeft className="w-5 h-5" />

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, Plus, Pencil, Route } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE, PAGE } from "../styles/tokens";
 import { CreateSpotModal } from "../components/CreateSpotModal";
 import { EditSpotModal } from "../components/EditSpotModal";
 import { SpotDetailsModal } from "../components/SpotDetailsModal";
@@ -27,7 +27,7 @@ export default function SpotsScene({ onRoute, onBack }: { onRoute: () => void; o
   }, []);
 
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3 space-y-3">
+    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className={`p-3 space-y-3 ${PAGE}`}>
       <div className="relative h-10">
         <Button
           variant="ghost"

--- a/src/scenes/TermsScene.tsx
+++ b/src/scenes/TermsScene.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
+import { BTN_GHOST_ICON, T_PRIMARY, T_MUTED, PAGE } from "../styles/tokens";
 import { useT } from "../i18n";
 
 export default function TermsScene({ onBack }: { onBack: () => void }) {
@@ -12,7 +12,7 @@ export default function TermsScene({ onBack }: { onBack: () => void }) {
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-3"
+      className={`p-3 space-y-3 ${PAGE}`}
     >
       <Button
         variant="ghost"

--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine } from "recharts";
-import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE, PAGE } from "../styles/tokens";
 import { MUSHROOMS } from "../data/mushrooms";
 import { generateForecast } from "../utils";
 import { useT } from "../i18n";
@@ -19,7 +19,7 @@ export default function ZoneScene({ zone, onGo, onAdd, onOpenShroom, onBack }: {
   if (!zone)
     return <div className={`p-6 ${T_PRIMARY}`}>{t("Sélectionnez une zone…")}</div>;
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
+    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className={`p-3 ${PAGE}`}>
       <Button
         variant="ghost"
         size="icon"

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -7,6 +7,7 @@ export const BTN =
   "inline-flex items-center justify-center rounded-md px-4 py-2 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 export const BTN_GHOST_ICON =
   "text-foreground hover:bg-foreground/10 focus-visible:ring-2 focus-visible:ring-accent rounded-md";
+export const PAGE = "min-h-screen bg-background text-foreground";
 export const T_PRIMARY = "text-foreground";
 export const T_MUTED = "text-foreground/70";
 export const T_SUBTLE = "text-foreground/50";


### PR DESCRIPTION
## Summary
- add PAGE layout token for consistent background and text across pages
- use PAGE in every scene component to align with landing style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d915d2088329a8559ef2691f5e16