### PR TITLE
Fix offline tagline grammar

### DIFF
--- a/src/i18n/landing.ts
+++ b/src/i18n/landing.ts
@@ -1,8 +1,8 @@
 export default {
   "forêt brumeuse": { fr: "forêt brumeuse", en: "misty forest" },
   "Logo": { fr: "Logo", en: "Logo" },
-  "Trouvez vos coins à champignons comestibles, même sans réseaux.": {
-    fr: "Trouvez vos coins à champignons comestibles, même sans réseaux.",
+  "Trouvez vos coins à champignons comestibles, même sans réseau.": {
+    fr: "Trouvez vos coins à champignons comestibles, même sans réseau.",
     en: "Find your edible mushroom spots, even offline.",
   },
   "Voir la carte": { fr: "Voir la carte", en: "See map" },

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -63,7 +63,7 @@ export default function LandingScene({
             className="mx-auto mb-8 w-28 h-28 rounded-[2rem] shadow-lg"
           />
           <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight bg-gradient-to-r from-forest via-moss to-fern bg-clip-text text-transparent">
-            {t("Trouvez vos coins à champignons comestibles, même sans réseaux.")}
+            {t("Trouvez vos coins à champignons comestibles, même sans réseau.")}
           </h1>
           <p className={`mt-6 text-lg ${T_MUTED}`}>
             {t("Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.")}


### PR DESCRIPTION
## Summary
- correct landing page tagline to use singular 'réseau'
- update French and English translations accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899da3cf91c83298e8b285712afb351