### PR TITLE
fix: make landing tagline green

### DIFF
--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -62,7 +62,7 @@ export default function LandingScene({
             alt={t("Logo")}
             className="mx-auto mb-8 w-28 h-28 rounded-[2rem] shadow-lg"
           />
-          <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight bg-gradient-to-r from-forest via-moss to-fern bg-clip-text text-transparent">
+          <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight text-forest">
             {t("Trouvez vos coins à champignons comestibles, même sans réseau.")}
           </h1>
           <p className={`mt-6 text-lg ${T_MUTED}`}>


### PR DESCRIPTION
## Summary
- use forest-green for landing tagline text instead of beige gradient for better visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e6028dd083298de00a30b7a4a599