### PR TITLE
Improve switch checked state contrast

### DIFF
--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -13,7 +13,11 @@ export function Switch({ checked = false, onCheckedChange, className = "" }: Swi
       role="switch"
       aria-checked={checked}
       onClick={() => onCheckedChange?.(!checked)}
-      className={`relative inline-flex h-6 w-10 items-center rounded-full border border-secondary bg-secondary transition-colors dark:border-secondary dark:bg-secondary ${checked ? "bg-primary dark:bg-primary" : ""} ${className}`}
+      className={`relative inline-flex h-6 w-10 items-center rounded-full border transition-colors ${
+        checked
+          ? "border-primary bg-primary dark:border-primary dark:bg-primary"
+          : "border-secondary bg-secondary dark:border-secondary dark:bg-secondary"
+      } ${className}`}
     >
       <span
         className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow transform transition-transform dark:bg-primary ${checked ? "translate-x-4" : "translate-x-0"}`}


### PR DESCRIPTION
## Summary
- highlight checked switch state with primary border/background to make check more visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e67295288329a79c0afe0c6738e1