### PR TITLE
Use logo for spot selection marker

### DIFF
--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -1,11 +1,12 @@
 import React, { useRef, useState, useEffect } from "react";
-import { X, MapPin, Plus, Pencil, Maximize2 } from "lucide-react";
+import { X, Plus, Pencil, Maximize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { useT } from "../i18n";
 import type { Spot, VisitHistory } from "../types";
 import { todayISO } from "../utils";
 import { loadMapKit } from "@/services/mapkit";
+import Logo from "/Logo.png";
 
 export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -54,10 +55,10 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
           <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
         </div>
 
-        <div className="relative h-48 rounded-xl overflow-hidden border border-neutral-300 dark:border-neutral-800 bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)] bg-neutral-100 dark:bg-neutral-900">
+        <div className="relative h-48 rounded-xl overflow-hidden border border-neutral-400 dark:border-neutral-700 bg-neutral-200 dark:bg-neutral-800">
           <div ref={mapContainerRef} className="absolute inset-0" />
-          <div className={`absolute top-2 left-2 px-2 py-1 rounded-lg text-xs bg-neutral-100/70 dark:bg-neutral-900/70 border border-neutral-300 dark:border-neutral-800 ${T_PRIMARY}`}>
-            <MapPin className="w-3 h-3 inline mr-1" />
+          <div className={`absolute top-2 left-2 px-2 py-1 rounded-lg text-xs bg-neutral-100/70 dark:bg-neutral-900/70 border border-neutral-400 dark:border-neutral-700 ${T_PRIMARY}`}>
+            <img src={Logo} className="w-3 h-3 inline mr-1" alt="" />
             {t("Carte du coin")}
           </div>
         </div>

--- a/src/components/__tests__/CreateSpotModal.test.tsx
+++ b/src/components/__tests__/CreateSpotModal.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import { AppProvider } from '@/context/AppContext';
+import { CreateSpotModal } from '../CreateSpotModal';
+import Logo from '/Logo.png';
+
+vi.mock('@/services/mapkit', () => ({
+  loadMapKit: vi.fn(() => Promise.resolve()),
+}));
+
+describe('CreateSpotModal', () => {
+  const MarkerAnnotation = vi.fn();
+
+  beforeEach(() => {
+    MarkerAnnotation.mockClear();
+    (global as any).mapkit = {
+      Map: class {
+        center = { latitude: 0, longitude: 0 };
+        addAnnotation = vi.fn();
+        removeAnnotation = vi.fn();
+        addEventListener = vi.fn();
+        destroy = vi.fn();
+      },
+      Coordinate: class {
+        latitude: number;
+        longitude: number;
+        constructor(lat: number, lng: number) {
+          this.latitude = lat;
+          this.longitude = lng;
+        }
+      },
+      CoordinateRegion: class {},
+      CoordinateSpan: class {},
+      MarkerAnnotation: MarkerAnnotation,
+      Image: class {
+        image: string;
+        constructor(src: string) {
+          this.image = src;
+        }
+      },
+    };
+  });
+
+  it('uses app logo for marker and shows map click instruction', async () => {
+    render(
+      <AppProvider>
+        <CreateSpotModal onClose={() => {}} onCreate={() => {}} />
+      </AppProvider>
+    );
+
+    await waitFor(() => expect(MarkerAnnotation).toHaveBeenCalled());
+    const [, options] = MarkerAnnotation.mock.calls[0];
+    expect(options.glyphImage.image).toBe(Logo);
+
+    expect(
+      screen.getByText('Cliquez sur la carte pour choisir la localisation')
+    ).toBeInTheDocument();
+  });
+});
+

--- a/src/i18n/common.ts
+++ b/src/i18n/common.ts
@@ -84,9 +84,9 @@ export default {
     fr: "Localisation (coordonnées ou lieu)",
     en: "Location (coordinates or place)",
   },
-  "Déplacez la carte pour choisir la localisation": {
-    fr: "Déplacez la carte pour choisir la localisation",
-    en: "Move the map to choose the location",
+  "Cliquez sur la carte pour choisir la localisation": {
+    fr: "Cliquez sur la carte pour choisir la localisation",
+    en: "Click on the map to choose the location",
   },
   "Sélectionnez un champignon…": { fr: "Sélectionnez un champignon…", en: "Select a mushroom…" },
   "comestible": { fr: "comestible", en: "edible" },


### PR DESCRIPTION
## Summary
- replace red pin with app logo and click-to-set marker when creating spots
- clarify map instructions and styling in spot details modal
- cover new marker and map instructions with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e5d8f2dc832981672dae2141b0c5