### PR TITLE
Remove About and Picking tips note

### DIFF
--- a/src/i18n/settings.ts
+++ b/src/i18n/settings.ts
@@ -29,8 +29,4 @@ export default {
   "Langue": { fr: "Langue", en: "Language" },
   "français": { fr: "français", en: "French" },
   "anglais": { fr: "anglais", en: "English" },
-  "« À propos » • « Conseils de cueillette »": {
-    fr: "« À propos » • « Conseils de cueillette »",
-    en: '"About" • "Picking tips"',
-  },
 };

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -188,9 +188,6 @@ export default function SettingsScene({
       </Card>
 
       <div className={`text-sm ${T_MUTED}`}>
-        {t("« À propos » • « Conseils de cueillette »")}
-      </div>
-      <div className={`text-sm ${T_MUTED}`}>
         <button onClick={onOpenPrivacy} className="underline">
           {t("Politique de confidentialité")}
         </button>


### PR DESCRIPTION
## Summary
- remove obsolete "À propos • Conseils de cueillette" note from settings scene
- drop related translation entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899f568873c8329904ff87302f8a503