### PR TITLE
Split landing tagline into responsive two lines

### DIFF
--- a/src/i18n/landing.ts
+++ b/src/i18n/landing.ts
@@ -1,10 +1,11 @@
 export default {
   "forêt brumeuse": { fr: "forêt brumeuse", en: "misty forest" },
   "Logo": { fr: "Logo", en: "Logo" },
-  "Trouvez vos coins à champignons comestibles, même sans réseau.": {
-    fr: "Trouvez vos coins à champignons comestibles, même sans réseau.",
-    en: "Find your edible mushroom spots, even offline.",
+  "Trouvez vos coins à champignons comestibles,": {
+    fr: "Trouvez vos coins à champignons comestibles,",
+    en: "Find your edible mushroom spots,",
   },
+  "même sans réseau.": { fr: "même sans réseau.", en: "even offline." },
   "Voir la carte": { fr: "Voir la carte", en: "See map" },
   "Les champignons": { fr: "Les champignons", en: "Mushrooms" },
   "Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.": {

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -63,7 +63,10 @@ export default function LandingScene({
             className="mx-auto mb-8 w-28 h-28 rounded-[2rem] shadow-lg"
           />
           <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight text-forest">
-            {t("Trouvez vos coins à champignons comestibles, même sans réseau.")}
+            <span className="block">
+              {t("Trouvez vos coins à champignons comestibles,")}
+            </span>
+            <span className="block">{t("même sans réseau.")}</span>
           </h1>
           <p className={`mt-6 text-lg ${T_MUTED}`}>
             {t("Mini‑pack offline inclus : carte topo (50 km) + fiches Cèpe, Girolle, Morille.")}


### PR DESCRIPTION
## Summary
- Break landing page headline into two stacked lines for better responsiveness
- Add matching i18n entries for each line in French and English

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f882daa48329b6f431803b97deab