### PR TITLE
Add random status badges and mushroom choices to map

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import { ChevronLeft, LocateFixed, Search, Navigation } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import { MUSHROOMS } from "../data/mushrooms";
 import { DEMO_ZONES } from "../data/zones";
 import { LEGEND } from "../data/legend";
@@ -12,10 +13,20 @@ import { loadMapKit } from "@/services/mapkit";
 import { useT } from "../i18n";
 import type { Zone } from "../types";
 
+const STATUS_BADGES = [
+  { label: "⬈ amélioration", color: "bg-emerald-700" },
+  { label: "→ stable", color: "bg-yellow-600" },
+  { label: "⬊ en baisse", color: "bg-red-600" },
+];
+
 export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow, onMapClick, onBack }: { onZone: (z: Zone) => void; onOpenShroom: (id: string) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onMapClick?: (msg: string) => void; onBack: () => void }) {
   const mapContainer = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
   const { t } = useT();
+  const statusBadges = useMemo(() => {
+    const count = Math.floor(Math.random() * STATUS_BADGES.length) + 1;
+    return [...STATUS_BADGES].sort(() => Math.random() - 0.5).slice(0, count);
+  }, []);
 
   useEffect(() => {
     if (mapRef.current || !mapContainer.current) return;
@@ -104,6 +115,20 @@ export default function MapScene({ onZone, onOpenShroom, gpsFollow, setGpsFollow
           ))}
         </div>
 
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {statusBadges.map((s, i) => (
+          <Badge key={i} className={s.color}>
+            {s.label}
+          </Badge>
+        ))}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {MUSHROOMS.map(m => (
+          <Button key={m.id} onClick={() => onOpenShroom(m.id)} className={BTN}>
+            {m.name}
+          </Button>
+        ))}
       </div>
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- Show random status badges in the map scene
- Restore mushroom choice buttons under the map for quick access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899f971a79c8329a984e69b1e952c64