### PR TITLE
Align auth controls to the left

### DIFF
--- a/src/scenes/LoginScene.tsx
+++ b/src/scenes/LoginScene.tsx
@@ -36,7 +36,7 @@ export default function LoginScene({
       exit={{ x: -20, opacity: 0 }}
       className="p-3 space-y-4"
     >
-      <header className="flex items-center justify-between">
+      <header className="flex items-center gap-2">
         <Button
           variant="ghost"
           size="icon"

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -88,7 +88,7 @@ export default function SettingsScene({
             </div>
           ) : (
             <div className="space-y-2">
-              <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
                 <Button onClick={onLogin} className={BTN}>
                   {t("Se connecter")}
                 </Button>


### PR DESCRIPTION
## Summary
- Align login and sign-up buttons to start in settings
- Place upgrade button next to back control in login header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899fd13f6e48329b2806e34e5dec75c