### PR TITLE
Improve login and signup page styling

### DIFF
--- a/src/scenes/LoginScene.tsx
+++ b/src/scenes/LoginScene.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY } from "../styles/tokens";
 import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
@@ -34,9 +35,9 @@ export default function LoginScene({
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-4"
+      className="min-h-screen flex flex-col items-center justify-center bg-background p-3"
     >
-      <header className="flex items-center justify-between">
+      <header className="flex items-center justify-between w-full max-w-sm mb-4">
         <Button
           variant="ghost"
           size="icon"
@@ -50,50 +51,54 @@ export default function LoginScene({
           {t("Passer en premium")}
         </Button>
       </header>
-      <div className="space-y-3">
-        <div className={`text-lg font-medium ${T_PRIMARY}`}>{t("Se connecter")}</div>
-        <Input
-          placeholder={t("Nom d'utilisateur")}
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <Input
-          type="password"
-          placeholder={t("Mot de passe")}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button onClick={handleLogin} className={BTN}>
-          {t("Se connecter")}
-        </Button>
-        <Button
-          onClick={() => {
-            loginWithProvider("google");
-            onBack();
-          }}
-          className={BTN}
-        >
-          {t("Se connecter avec Google")}
-        </Button>
-        <Button
-          onClick={() => {
-            loginWithProvider("apple");
-            onBack();
-          }}
-          className={BTN}
-        >
-          {t("Se connecter avec Apple")}
-        </Button>
-        <button type="button" className="text-sm underline" onClick={() => {}}>
-          {t("Mot de passe oublié ?")}
-        </button>
-        <p className="text-sm">
-          {t("Pas encore de compte ?")} {" "}
-          <button type="button" onClick={onSignup} className="underline">
-            {t("Créer un compte")}
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className={`text-center ${T_PRIMARY}`}>{t("Se connecter")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Input
+            placeholder={t("Nom d'utilisateur")}
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder={t("Mot de passe")}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button onClick={handleLogin} className={`${BTN} w-full`}>
+            {t("Se connecter")}
+          </Button>
+          <Button
+            onClick={() => {
+              loginWithProvider("google");
+              onBack();
+            }}
+            className={`${BTN} w-full`}
+          >
+            {t("Se connecter avec Google")}
+          </Button>
+          <Button
+            onClick={() => {
+              loginWithProvider("apple");
+              onBack();
+            }}
+            className={`${BTN} w-full`}
+          >
+            {t("Se connecter avec Apple")}
+          </Button>
+          <button type="button" className="text-sm underline" onClick={() => {}}>
+            {t("Mot de passe oublié ?")}
           </button>
-        </p>
-      </div>
+          <p className="text-sm text-center">
+            {t("Pas encore de compte ?")} {" "}
+            <button type="button" onClick={onSignup} className="underline">
+              {t("Créer un compte")}
+            </button>
+          </p>
+        </CardContent>
+      </Card>
     </motion.section>
   );
 }

--- a/src/scenes/SignupScene.tsx
+++ b/src/scenes/SignupScene.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY } from "../styles/tokens";
 import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
@@ -44,37 +45,49 @@ export default function SignupScene({ onLogin, onBack }: { onLogin: () => void; 
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-4"
+      className="min-h-screen flex flex-col items-center justify-center bg-background p-3"
     >
-      <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
-        <ChevronLeft className="w-5 h-5" />
-      </Button>
-      <div className="space-y-3">
-        <div className={`text-lg font-medium ${T_PRIMARY}`}>{t("Créer un compte")}</div>
-        <Input
-          placeholder={t("Nom d'utilisateur")}
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <Input
-          type="password"
-          placeholder={t("Mot de passe")}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button onClick={handleSignup} className={BTN}>
-          {t("Créer un compte")}
-        </Button>
-        <Button onClick={() => handleProviderSignup("google")} className={BTN}>
-          {t("Créer un compte avec Google")}
-        </Button>
-        <Button onClick={() => handleProviderSignup("apple")} className={BTN}>
-          {t("Créer un compte avec Apple")}
-        </Button>
-        <Button onClick={onLogin} className={BTN} variant="ghost">
-          {t("Se connecter")}
+      <div className="w-full max-w-sm mb-4">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          className={BTN_GHOST_ICON}
+          aria-label={t("Retour")}
+        >
+          <ChevronLeft className="w-5 h-5" />
         </Button>
       </div>
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className={`text-center ${T_PRIMARY}`}>{t("Créer un compte")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Input
+            placeholder={t("Nom d'utilisateur")}
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder={t("Mot de passe")}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button onClick={handleSignup} className={`${BTN} w-full`}>
+            {t("Créer un compte")}
+          </Button>
+          <Button onClick={() => handleProviderSignup("google")} className={`${BTN} w-full`}>
+            {t("Créer un compte avec Google")}
+          </Button>
+          <Button onClick={() => handleProviderSignup("apple")} className={`${BTN} w-full`}>
+            {t("Créer un compte avec Apple")}
+          </Button>
+          <Button onClick={onLogin} className={`${BTN} w-full`} variant="ghost">
+            {t("Se connecter")}
+          </Button>
+        </CardContent>
+      </Card>
     </motion.section>
   );
 }


### PR DESCRIPTION
## Summary
- Center login and signup forms in a card layout
- Use full-width inputs and buttons for clearer call to action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899fd2c5ac88329b476a90818512781