### PR TITLE
Center login and signup pages in styled card

### DIFF
--- a/src/scenes/LoginScene.tsx
+++ b/src/scenes/LoginScene.tsx
@@ -34,65 +34,67 @@ export default function LoginScene({
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-4"
+      className="min-h-screen flex items-center justify-center p-3"
     >
-      <header className="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onBack}
-          className={BTN_GHOST_ICON}
-          aria-label={t("Retour")}
-        >
-          <ChevronLeft className="w-5 h-5" />
-        </Button>
-        <Button variant="ghost" onClick={onPremium} className="text-sm underline p-0">
-          {t("Passer en premium")}
-        </Button>
-      </header>
-      <div className="space-y-3">
-        <div className={`text-lg font-medium ${T_PRIMARY}`}>{t("Se connecter")}</div>
-        <Input
-          placeholder={t("Nom d'utilisateur")}
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <Input
-          type="password"
-          placeholder={t("Mot de passe")}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button onClick={handleLogin} className={BTN}>
-          {t("Se connecter")}
-        </Button>
-        <Button
-          onClick={() => {
-            loginWithProvider("google");
-            onBack();
-          }}
-          className={BTN}
-        >
-          {t("Se connecter avec Google")}
-        </Button>
-        <Button
-          onClick={() => {
-            loginWithProvider("apple");
-            onBack();
-          }}
-          className={BTN}
-        >
-          {t("Se connecter avec Apple")}
-        </Button>
-        <button type="button" className="text-sm underline" onClick={() => {}}>
-          {t("Mot de passe oublié ?")}
-        </button>
-        <p className="text-sm">
-          {t("Pas encore de compte ?")} {" "}
-          <button type="button" onClick={onSignup} className="underline">
-            {t("Créer un compte")}
+      <div className="w-full max-w-md space-y-4 p-6 rounded-xl bg-background/60 backdrop-blur-md shadow-lg">
+        <header className="flex items-center justify-between gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onBack}
+            className={BTN_GHOST_ICON}
+            aria-label={t("Retour")}
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </Button>
+          <Button variant="ghost" onClick={onPremium} className="text-sm underline p-0">
+            {t("Passer en premium")}
+          </Button>
+        </header>
+        <div className="space-y-3">
+          <div className={`text-lg font-medium text-center ${T_PRIMARY}`}>{t("Se connecter")}</div>
+          <Input
+            placeholder={t("Nom d'utilisateur")}
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder={t("Mot de passe")}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button onClick={handleLogin} className={BTN}>
+            {t("Se connecter")}
+          </Button>
+          <Button
+            onClick={() => {
+              loginWithProvider("google");
+              onBack();
+            }}
+            className={BTN}
+          >
+            {t("Se connecter avec Google")}
+          </Button>
+          <Button
+            onClick={() => {
+              loginWithProvider("apple");
+              onBack();
+            }}
+            className={BTN}
+          >
+            {t("Se connecter avec Apple")}
+          </Button>
+          <button type="button" className="text-sm underline" onClick={() => {}}>
+            {t("Mot de passe oublié ?")}
           </button>
-        </p>
+          <p className="text-sm text-center">
+            {t("Pas encore de compte ?")} {" "}
+            <button type="button" onClick={onSignup} className="underline">
+              {t("Créer un compte")}
+            </button>
+          </p>
+        </div>
       </div>
     </motion.section>
   );

--- a/src/scenes/SignupScene.tsx
+++ b/src/scenes/SignupScene.tsx
@@ -44,36 +44,46 @@ export default function SignupScene({ onLogin, onBack }: { onLogin: () => void; 
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="p-3 space-y-4"
+      className="min-h-screen flex items-center justify-center p-3"
     >
-      <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
-        <ChevronLeft className="w-5 h-5" />
-      </Button>
-      <div className="space-y-3">
-        <div className={`text-lg font-medium ${T_PRIMARY}`}>{t("Créer un compte")}</div>
-        <Input
-          placeholder={t("Nom d'utilisateur")}
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <Input
-          type="password"
-          placeholder={t("Mot de passe")}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button onClick={handleSignup} className={BTN}>
-          {t("Créer un compte")}
-        </Button>
-        <Button onClick={() => handleProviderSignup("google")} className={BTN}>
-          {t("Créer un compte avec Google")}
-        </Button>
-        <Button onClick={() => handleProviderSignup("apple")} className={BTN}>
-          {t("Créer un compte avec Apple")}
-        </Button>
-        <Button onClick={onLogin} className={BTN} variant="ghost">
-          {t("Se connecter")}
-        </Button>
+      <div className="w-full max-w-md space-y-4 p-6 rounded-xl bg-background/60 backdrop-blur-md shadow-lg">
+        <header className="flex items-center">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onBack}
+            className={BTN_GHOST_ICON}
+            aria-label={t("Retour")}
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </Button>
+        </header>
+        <div className="space-y-3">
+          <div className={`text-lg font-medium text-center ${T_PRIMARY}`}>{t("Créer un compte")}</div>
+          <Input
+            placeholder={t("Nom d'utilisateur")}
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder={t("Mot de passe")}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button onClick={handleSignup} className={BTN}>
+            {t("Créer un compte")}
+          </Button>
+          <Button onClick={() => handleProviderSignup("google")} className={BTN}>
+            {t("Créer un compte avec Google")}
+          </Button>
+          <Button onClick={() => handleProviderSignup("apple")} className={BTN}>
+            {t("Créer un compte avec Apple")}
+          </Button>
+          <Button onClick={onLogin} className={BTN} variant="ghost">
+            {t("Se connecter")}
+          </Button>
+        </div>
       </div>
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- Center login screen in a card with backdrop blur and premium link aligned opposite back button
- Center signup screen and add matching card styling for consistent look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ff34cfa4832991c98ce6b7eb7b92