### PR TITLE
Improve clarity of login and signup screens

### DIFF
--- a/src/components/AuthProviders.tsx
+++ b/src/components/AuthProviders.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { BTN } from "../styles/tokens";
+import { useT } from "../i18n";
+
+interface AuthProvidersProps {
+  onProvider: (provider: "google" | "apple") => void;
+  mode: "login" | "signup";
+}
+
+export function AuthProviders({ onProvider, mode }: AuthProvidersProps) {
+  const { t } = useT();
+
+  const labels = {
+    login: {
+      google: t("Se connecter avec Google"),
+      apple: t("Se connecter avec Apple"),
+    },
+    signup: {
+      google: t("Créer un compte avec Google"),
+      apple: t("Créer un compte avec Apple"),
+    },
+  } as const;
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={() => onProvider("google")} className={BTN}>
+        {labels[mode].google}
+      </Button>
+      <Button onClick={() => onProvider("apple")} className={BTN}>
+        {labels[mode].apple}
+      </Button>
+    </div>
+  );
+}
+
+export default AuthProviders;

--- a/src/scenes/LoginScene.tsx
+++ b/src/scenes/LoginScene.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY } from "../styles/tokens";
 import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
+import AuthProviders from "../components/AuthProviders";
 
 export default function LoginScene({
   onSignup,
@@ -51,40 +52,49 @@ export default function LoginScene({
             {t("Passer en premium")}
           </Button>
         </header>
-        <div className="space-y-3">
+        <div className="space-y-4">
           <div className={`text-lg font-medium text-center ${T_PRIMARY}`}>{t("Se connecter")}</div>
-          <Input
-            placeholder={t("Nom d'utilisateur")}
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-          />
-          <Input
-            type="password"
-            placeholder={t("Mot de passe")}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <Button onClick={handleLogin} className={BTN}>
-            {t("Se connecter")}
-          </Button>
-          <Button
-            onClick={() => {
-              loginWithProvider("google");
-              onBack();
+          <form
+            className="space-y-3"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleLogin();
             }}
-            className={BTN}
           >
-            {t("Se connecter avec Google")}
-          </Button>
-          <Button
-            onClick={() => {
-              loginWithProvider("apple");
-              onBack();
-            }}
-            className={BTN}
-          >
-            {t("Se connecter avec Apple")}
-          </Button>
+            <div className="space-y-1">
+              <label htmlFor="username" className="text-sm font-medium">
+                {t("Nom d'utilisateur")}
+              </label>
+              <Input
+                id="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="password" className="text-sm font-medium">
+                {t("Mot de passe")}
+              </label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+            <Button type="submit" className={BTN}>
+              {t("Se connecter")}
+            </Button>
+          </form>
+          <div className="pt-2 border-t">
+            <AuthProviders
+              mode="login"
+              onProvider={(provider) => {
+                loginWithProvider(provider);
+                onBack();
+              }}
+            />
+          </div>
           <button type="button" className="text-sm underline" onClick={() => {}}>
             {t("Mot de passe oublié ?")}
           </button>

--- a/src/scenes/SignupScene.tsx
+++ b/src/scenes/SignupScene.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../context/AuthContext";
 import { useT } from "../i18n";
 import { useNavigate } from "react-router-dom";
 import { Scene } from "../routes";
+import AuthProviders from "../components/AuthProviders";
 
 export default function SignupScene({ onLogin, onBack }: { onLogin: () => void; onBack: () => void }) {
   const { signup, loginWithProvider } = useAuth();
@@ -58,28 +59,43 @@ export default function SignupScene({ onLogin, onBack }: { onLogin: () => void; 
             <ChevronLeft className="w-5 h-5" />
           </Button>
         </header>
-        <div className="space-y-3">
+        <div className="space-y-4">
           <div className={`text-lg font-medium text-center ${T_PRIMARY}`}>{t("Créer un compte")}</div>
-          <Input
-            placeholder={t("Nom d'utilisateur")}
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-          />
-          <Input
-            type="password"
-            placeholder={t("Mot de passe")}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <Button onClick={handleSignup} className={BTN}>
-            {t("Créer un compte")}
-          </Button>
-          <Button onClick={() => handleProviderSignup("google")} className={BTN}>
-            {t("Créer un compte avec Google")}
-          </Button>
-          <Button onClick={() => handleProviderSignup("apple")} className={BTN}>
-            {t("Créer un compte avec Apple")}
-          </Button>
+          <form
+            className="space-y-3"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSignup();
+            }}
+          >
+            <div className="space-y-1">
+              <label htmlFor="username" className="text-sm font-medium">
+                {t("Nom d'utilisateur")}
+              </label>
+              <Input
+                id="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="password" className="text-sm font-medium">
+                {t("Mot de passe")}
+              </label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+            <Button type="submit" className={BTN}>
+              {t("Créer un compte")}
+            </Button>
+          </form>
+          <div className="pt-2 border-t">
+            <AuthProviders mode="signup" onProvider={handleProviderSignup} />
+          </div>
           <Button onClick={onLogin} className={BTN} variant="ghost">
             {t("Se connecter")}
           </Button>


### PR DESCRIPTION
## Summary
- refactor login screen with labeled fields and provider section
- refactor signup screen with labeled fields and shared provider buttons
- create reusable AuthProviders component for OAuth options

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a042d6408832998b2b0ae712ae169