### PR TITLE
Improve switch visibility

### DIFF
--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -20,7 +20,9 @@ export function Switch({ checked = false, onCheckedChange, className = "" }: Swi
       } ${className}`}
     >
       <span
-        className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow transform transition-transform dark:bg-primary ${checked ? "translate-x-4" : "translate-x-0"}`}
+        className={`pointer-events-none block h-5 w-5 rounded-full bg-white dark:bg-white border border-border shadow transform transition-transform ${
+          checked ? "translate-x-4" : "translate-x-0"
+        }`}
       />
     </button>
   );


### PR DESCRIPTION
## Summary
- keep switch thumb white in dark mode
- add thumb border for better contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a05a280808329acacc2cc2c92bfa9