### PR TITLE
Optimize animations for smoother transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap"
       rel="stylesheet"
     />
+    <link rel="preload" as="image" href="/src/assets/logo.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -108,7 +108,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
               {photos.slice(0, 5).map((p: string, i: number) => (
                 <button key={i} onClick={() => setLightbox({ open: true, index: i })} className="relative group">
                   <img src={p} className="w-full h-28 object-cover rounded-xl border border-neutral-300 dark:border-neutral-800" />
-                  <div className="absolute inset-0 rounded-xl bg-black/0 group-hover:bg-black/20 transition" />
+                  <div className="absolute inset-0 rounded-xl bg-black/0 group-hover:bg-black/20 transition" style={{ willChange: "opacity" }} />
                   <Maximize2 className="absolute right-2 bottom-2 w-4 h-4 text-white opacity-0 group-hover:opacity-100" />
                 </button>
               ))}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,10 +7,10 @@ interface ProgressProps {
 
 export function Progress({ value = 0, className = "" }: ProgressProps) {
   return (
-    <div className={`w-full h-2 rounded-full bg-secondary dark:bg-secondary ${className}`}>
+    <div className={`w-full h-2 rounded-full bg-secondary dark:bg-secondary overflow-hidden ${className}`}>
       <div
-        className="h-2 rounded-full bg-primary dark:bg-primary transition-all"
-        style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+        className="h-full rounded-full bg-primary dark:bg-primary transition-transform will-change-transform origin-left"
+        style={{ transform: `scaleX(${Math.min(1, Math.max(0, value / 100))})` }}
       />
     </div>
   );

--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -23,6 +23,7 @@ export default function LandingScene({
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
+      style={{ willChange: "opacity" }}
       className="relative min-h-screen overflow-hidden bg-background text-foreground"
     >
       <div className="absolute top-3 right-3 z-20">
@@ -42,11 +43,13 @@ export default function LandingScene({
           className="absolute -top-40 left-1/2 w-[60rem] h-[60rem] -translate-x-1/2 rounded-full bg-forest/30 blur-3xl"
           animate={{ rotate: [0, 360] }}
           transition={{ duration: 30, repeat: Infinity, ease: "linear" }}
+          style={{ willChange: "transform" }}
         />
         <motion.div
           className="absolute bottom-0 left-1/2 w-[80rem] h-[80rem] -translate-x-1/2 rounded-full bg-moss/20 blur-3xl mix-blend-multiply"
           animate={{ rotate: [0, -360] }}
           transition={{ duration: 40, repeat: Infinity, ease: "linear" }}
+          style={{ willChange: "transform" }}
         />
       </div>
 
@@ -55,6 +58,7 @@ export default function LandingScene({
           initial={{ y: 20, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           transition={{ delay: 0.2 }}
+          style={{ willChange: "transform, opacity" }}
           className="max-w-xl p-10 rounded-3xl bg-background/60 backdrop-blur-xl border border-border/50 shadow-2xl"
         >
           <img


### PR DESCRIPTION
## Summary
- Hint the browser to pre-render key landing scene animations with `will-change`
- Preload logo asset to reduce blocking on first paint
- Refactor progress bar to use GPU-friendly transforms for smoother updates
- Prepare hover overlay in spot details with `will-change` to minimize jank

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a0855e4008329a5f21e18ad1ed2de