### PR TITLE
feat: align map click notifications with legend style

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,7 +141,6 @@ function AppContent() {
                   onBack={goBack}
                   gpsFollow={gpsFollow}
                   setGpsFollow={setGpsFollow}
-                  onMapClick={(msg) => pushToast({ type: "success", text: msg })}
                   onZone={(z) => {
                     setSelectedZone(z);
                     goTo(Scene.Zone);

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -12,11 +12,16 @@ import { loadMap } from "@/services/openstreetmap";
 import { useT } from "../i18n";
 import type { Zone } from "../types";
 
-export default function MapScene({ onZone, gpsFollow, setGpsFollow, onMapClick, onBack }: { onZone: (z: Zone) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onMapClick?: (msg: string) => void; onBack: () => void }) {
+export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { onZone: (z: Zone) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onBack: () => void }) {
   const mapContainer = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
   const { t } = useT();
   const [selected, setSelected] = useState<string[]>([]);
+  const [toast, setToast] = useState<string | null>(null);
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 5000);
+  };
   const toggleShroom = (id: string) =>
     setSelected(prev =>
       prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]
@@ -52,8 +57,8 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onMapClick, 
               return `${name} ${sc}%`;
             })
             .join("\n");
-          const msg = `${nearest.name}\n${nearest.score}% ${nearest.trend}\n${speciesLines}`;
-          onMapClick?.(msg);
+            const msg = `${nearest.name}\n${nearest.score}% ${nearest.trend}\n${speciesLines}`;
+            showToast(msg);
         }
       });
     });
@@ -109,6 +114,11 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onMapClick, 
             </div>
           ))}
         </div>
+        {toast && (
+          <div className="absolute left-3 top-16 bg-secondary/80 dark:bg-secondary/80 backdrop-blur rounded-xl p-2 border border-secondary dark:border-secondary">
+            <div className={`text-xs whitespace-pre-line ${T_PRIMARY}`}>{toast}</div>
+          </div>
+        )}
 
       </div>
       <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- show map click info in MapScene instead of global toast
- style map notifications like the legend and position them below it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0cda5d7c83298560ec62e0320913