### PR TITLE
Fix map rendering in CreateSpotModal

### DIFF
--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -62,11 +62,12 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
     loadMap().then(maplibregl => {
       const map = new maplibregl.Map({
         container: mapContainerRef.current as HTMLDivElement,
-        style: "https://demotiles.maplibre.org/style.json",
+        style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
         center: [2.3522, 48.8566],
         zoom: 10,
       });
       mapRef.current = map;
+      map.on("load", () => map.resize());
 
       const updateLocation = () => {
         const c = map.getCenter();
@@ -110,7 +111,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
           <div>
             <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Localisation")}</div>
             <div className="relative h-48 rounded-xl border border-neutral-400 dark:border-neutral-700 bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
-              <div ref={mapContainerRef} className="absolute inset-0" />
+              <div ref={mapContainerRef} className="absolute inset-0 w-full h-full" />
               <img
                 src={Logo}
                 className="absolute left-1/2 top-1/2 w-8 h-8 -translate-x-1/2 -translate-y-1/2 pointer-events-none"


### PR DESCRIPTION
## Summary
- ensure MapLibre map displays in CreateSpotModal by using reliable basemap style and resizing on load
- give map container explicit dimensions to properly fill modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0fb35fdc832998e0aeac6b828d48