### PR TITLE
Add stats stack component

### DIFF
--- a/src/components/StatsStack.tsx
+++ b/src/components/StatsStack.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import { Card, CardContent } from "./ui/card";
+import { Button } from "./ui/button";
+
+type StatItem = {
+  label: string;
+  percent: string;
+  down?: boolean;
+};
+
+const data: StatItem[] = [
+  { label: "Ripisylve du Vieux Pont", percent: "72% ⬊", down: true },
+  { label: "Cèpe", percent: "40%" },
+  { label: "Girolle", percent: "55%" },
+  { label: "Morille", percent: "85%" }
+];
+
+export function StatsStack() {
+  const [items, setItems] = useState<StatItem[]>([]);
+  const [index, setIndex] = useState(0);
+
+  const addItem = () => {
+    setItems(prev => {
+      const next = [...prev, data[index % data.length]];
+      return next.slice(-3);
+    });
+    setIndex(i => i + 1);
+  };
+
+  return (
+    <div>
+      <Button onClick={addItem}>Ajouter une carte</Button>
+      <div className="mt-4 flex flex-col gap-2">
+        {items.map((item, idx) => (
+          <Card key={idx} data-testid="stat-card">
+            <CardContent className="flex justify-between">
+              <span className="font-semibold">{item.label}</span>
+              <span className={item.down ? "text-danger" : ""}>{item.percent}</span>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default StatsStack;

--- a/src/components/__tests__/StatsStack.test.tsx
+++ b/src/components/__tests__/StatsStack.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { StatsStack } from "../StatsStack";
+
+describe("StatsStack", () => {
+  it("stacks at most three cards", () => {
+    render(<StatsStack />);
+    const button = screen.getByRole("button", { name: /ajouter une carte/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(screen.getAllByTestId("stat-card")).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add `StatsStack` component cycling mushroom stat cards and limiting stack to three
- test that card stack never exceeds three items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a10df56988329b7bd97284b51af0b