### PR TITLE
Fix coordinate order for spot locations

### DIFF
--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -71,7 +71,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
 
       const updateLocation = () => {
         const c = map.getCenter();
-        setLocation(`${c.lng.toFixed(5)}, ${c.lat.toFixed(5)}`);
+        setLocation(`${c.lat.toFixed(5)}, ${c.lng.toFixed(5)}`);
       };
 
       updateLocation();

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -21,8 +21,8 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
 
   useEffect(() => {
     if (!spot.location || mapRef.current || !mapContainerRef.current) return;
-    const [lng, lat] = spot.location.split(",").map((v) => parseFloat(v.trim()));
-    if (Number.isNaN(lng) || Number.isNaN(lat)) return;
+    const [lat, lng] = spot.location.split(",").map((v) => parseFloat(v.trim()));
+    if (Number.isNaN(lat) || Number.isNaN(lng)) return;
     loadMap().then(maplibregl => {
       const map = new maplibregl.Map({
         container: mapContainerRef.current as HTMLDivElement,

--- a/src/i18n/common.ts
+++ b/src/i18n/common.ts
@@ -6,7 +6,7 @@ export default {
   },
   "Créé": { fr: "Créé", en: "Created" },
   "Coin ajouté": { fr: "Coin ajouté", en: "Spot added" },
-  "Map clicked at {lng}, {lat}": { fr: "Carte cliquée à {lng}, {lat}", en: "Map clicked at {lng}, {lat}" },
+  "Map clicked at {lat}, {lng}": { fr: "Carte cliquée à {lat}, {lng}", en: "Map clicked at {lat}, {lng}" },
   "Zone clicked: {name}": { fr: "Zone cliquée : {name}", en: "Zone clicked: {name}" },
   "Espace insuffisant. Libérez {n} Mo": {
     fr: "Espace insuffisant. Libérez {n} Mo",

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -23,7 +23,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
 
   const openRoute = (spot: Spot) => {
     if (!spot.location) return;
-    const [lng, lat] = spot.location.split(",").map(v => parseFloat(v.trim()));
+    const [lat, lng] = spot.location.split(",").map(v => parseFloat(v.trim()));
     if (Number.isNaN(lat) || Number.isNaN(lng)) return;
     window.open(`https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`, "_blank");
   };


### PR DESCRIPTION
## Summary
- store selected locations as latitude, longitude
- display and parse spot coordinates in latitude, longitude order
- update translation string for map click coordinate format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a18cd39f8832990f1f7df88725976