### PR TITLE
Revert toast stacking changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,7 @@ function AppContent() {
     });
     setTimeout(() => {
       setToasts((curr) => curr.filter((t) => t.id !== id));
-    }, 45000);
+    }, 5000);
   }, []);
 
   useEffect(() => {
@@ -145,7 +145,6 @@ function AppContent() {
                     setSelectedZone(z);
                     goTo(Scene.Zone);
                   }}
-                  pushToast={pushToast}
                 />
               }
             />

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -12,11 +12,16 @@ import { loadMap } from "@/services/openstreetmap";
 import { useT } from "../i18n";
 import type { Zone } from "../types";
 
-export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack, pushToast }: { onZone: (z: Zone) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onBack: () => void; pushToast: (t: { type: "success" | "warn"; text: string }) => void }) {
+export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { onZone: (z: Zone) => void; gpsFollow: boolean; setGpsFollow: React.Dispatch<React.SetStateAction<boolean>>; onBack: () => void }) {
   const mapContainer = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
   const { t } = useT();
   const [selected, setSelected] = useState<string[]>([]);
+  const [toast, setToast] = useState<string | null>(null);
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 5000);
+  };
   const toggleShroom = (id: string) =>
     setSelected(prev =>
       prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]
@@ -53,7 +58,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack, push
             })
             .join("\n");
             const msg = `${nearest.name}\n${nearest.score}% ${nearest.trend}\n${speciesLines}`;
-            pushToast({ type: "warn", text: msg });
+            showToast(msg);
         }
       });
     });
@@ -109,6 +114,12 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack, push
             </div>
           ))}
         </div>
+        {toast && (
+          <div className="absolute left-3 top-16 bg-secondary/80 dark:bg-secondary/80 backdrop-blur rounded-xl p-2 border border-secondary dark:border-secondary">
+            <div className={`text-xs whitespace-pre-line ${T_PRIMARY}`}>{toast}</div>
+          </div>
+        )}
+
       </div>
       <div className="mt-4 flex flex-wrap gap-2">
         {MUSHROOMS.map(m => (


### PR DESCRIPTION
## Summary
- Restore default 5s toast timeout
- Revert MapScene to use its own transient toast messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a1e0413108329b93640d82d0fb30b