### PR TITLE
Enable search bars for zones

### DIFF
--- a/src/scenes/DownloadScene.tsx
+++ b/src/scenes/DownloadScene.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { motion } from "framer-motion";
 import { ChevronLeft, Download, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -9,9 +9,20 @@ import { Progress } from "@/components/ui/progress";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { Row } from "../components/Row";
 import { useT } from "../i18n";
+import { DEMO_ZONES } from "../data/zones";
+import type { Zone } from "../types";
 
 export default function DownloadScene({ packSize, setPackSize, deviceFree, setDeviceFree, includeRelief, setIncludeRelief, includeWeather, setIncludeWeather, downloading, dlProgress, onStart, onCancel, onBack }: { packSize: number; setPackSize: (n: number) => void; deviceFree: number; setDeviceFree: (n: number) => void; includeRelief: boolean; setIncludeRelief: (v: boolean) => void; includeWeather: boolean; setIncludeWeather: (v: boolean) => void; downloading: boolean; dlProgress: number; onStart: () => void; onCancel: () => void; onBack: () => void }) {
   const { t } = useT();
+  const [search, setSearch] = useState("");
+  const [zone, setZone] = useState<Zone | null>(null);
+  const matches = useMemo(
+    () =>
+      DEMO_ZONES.filter(z =>
+        z.name.toLowerCase().includes(search.toLowerCase())
+      ),
+    [search]
+  );
   useEffect(() => {
     const base = 120;
     const size = base + (includeRelief ? 30 : 0) + (includeWeather ? 30 : 0);
@@ -23,10 +34,29 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
       <div className="flex items-center gap-2 mb-3">
         <div className="relative flex-1">
           <Input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
             placeholder={t("Rechercher une zone…")}
             className={`pl-9 bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
           />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
+          {search && matches.length > 0 && (
+            <ul className="absolute z-10 left-0 right-0 mt-1 max-h-40 overflow-auto rounded-xl border border-secondary dark:border-secondary bg-secondary dark:bg-secondary">
+              {matches.map(z => (
+                <li key={z.id}>
+                  <button
+                    onClick={() => {
+                      setZone(z);
+                      setSearch("");
+                    }}
+                    className={`w-full text-left px-3 py-1 ${T_PRIMARY} hover:bg-secondary dark:hover:bg-secondary`}
+                  >
+                    {z.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
         <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />
@@ -35,7 +65,7 @@ export default function DownloadScene({ packSize, setPackSize, deviceFree, setDe
       <div className="relative h-[50vh] rounded-2xl border border-secondary dark:border-secondary overflow-hidden bg-[conic-gradient(at_30%_30%,#14532d,#052e16,#14532d)] bg-secondary dark:bg-secondary">
         <div className="absolute inset-6 border-2 border-red-600 rounded-xl" />
         <div className={`absolute top-3 left-3 bg-secondary/80 dark:bg-secondary/80 rounded-xl px-3 py-1 text-sm ${T_PRIMARY}`}>
-          {t("Vue actuelle")}
+          {zone ? zone.name : t("Vue actuelle")}
         </div>
       </div>
 

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from "react";
+import React, { useRef, useEffect, useState, useMemo } from "react";
 import { motion } from "framer-motion";
 import { ChevronLeft, LocateFixed, Search, Navigation } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -18,6 +18,14 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
   const { t } = useT();
   const [selected, setSelected] = useState<string[]>([]);
   const [toast, setToast] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const results = useMemo(
+    () =>
+      DEMO_ZONES.filter(z =>
+        z.name.toLowerCase().includes(query.toLowerCase())
+      ),
+    [query]
+  );
   const showToast = (msg: string) => {
     setToast(msg);
     setTimeout(() => setToast(null), 5000);
@@ -71,15 +79,35 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
   return (
     <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
       <div className="flex items-center gap-2 mb-3">
-        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
+      <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />
         </Button>
         <div className="relative flex-1">
           <Input
+            value={query}
+            onChange={e => setQuery(e.target.value)}
             placeholder={t("Rechercher un lieu…")}
             className={`pl-9 bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
           />
           <Search className={`w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 ${T_MUTED}`} />
+          {query && results.length > 0 && (
+            <ul className="absolute z-10 left-0 right-0 mt-1 max-h-40 overflow-auto rounded-xl border border-secondary dark:border-secondary bg-secondary dark:bg-secondary">
+              {results.map(z => (
+                <li key={z.id}>
+                  <button
+                    onClick={() => {
+                      mapRef.current?.setCenter([z.coords[1], z.coords[0]]);
+                      showToast(z.name);
+                      setQuery("");
+                    }}
+                    className={`w-full text-left px-3 py-1 ${T_PRIMARY} hover:bg-secondary dark:hover:bg-secondary`}
+                  >
+                    {z.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
         <Button
           onClick={() => setGpsFollow(v => !v)}


### PR DESCRIPTION
## Summary
- implement zone search in Map and Download scenes
- center map or display zone after selecting search result

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a20144f608329a413f6bc521db914