### PR TITLE
Use site palette for premium button

### DIFF
--- a/src/scenes/LoginScene.tsx
+++ b/src/scenes/LoginScene.tsx
@@ -50,7 +50,7 @@ export default function LoginScene({
           </Button>
           <Button
             onClick={onPremium}
-            className={`${BTN} bg-gold text-foreground hover:bg-gold/90`}
+            className={`${BTN} focus-visible:ring-forest`}
           >
             {t("Passer en premium")}
           </Button>

--- a/src/scenes/PremiumScene.tsx
+++ b/src/scenes/PremiumScene.tsx
@@ -28,7 +28,7 @@ export default function PremiumScene({ onBack }: { onBack: () => void }) {
             upgrade();
             onBack();
           }}
-          className={`${BTN} bg-gold text-foreground hover:bg-gold/90`}
+          className={`${BTN} focus-visible:ring-forest`}
         >
           {t("Passer en premium")}
         </Button>

--- a/src/scenes/SettingsScene.tsx
+++ b/src/scenes/SettingsScene.tsx
@@ -75,7 +75,7 @@ export default function SettingsScene({
               {!user.premium ? (
                 <Button
                   onClick={handlePremium}
-                  className={`${BTN} bg-gold text-foreground hover:bg-gold/90`}
+                  className={`${BTN} focus-visible:ring-forest`}
                 >
                   {t("Passer en premium")}
                 </Button>
@@ -98,7 +98,7 @@ export default function SettingsScene({
               </div>
               <Button
                 onClick={handlePremium}
-                className={`${BTN} bg-gold text-foreground hover:bg-gold/90`}
+                className={`${BTN} focus-visible:ring-forest`}
               >
                 {t("Passer en premium")}
               </Button>


### PR DESCRIPTION
## Summary
- restyle 'Passer en premium' CTA to use default site palette and ring

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2107f1e483298ce91c69ff8c1ec0