### PR TITLE
feat: add glass card token

### DIFF
--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { BTN, BTN_GHOST_ICON, T_MUTED } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, GLASS_CARD, T_MUTED } from "../styles/tokens";
 import { useT } from "../i18n";
 import logo from "@/assets/logo.png";
 
@@ -59,7 +59,7 @@ export default function LandingScene({
           animate={{ y: 0, opacity: 1 }}
           transition={{ delay: 0.2 }}
           style={{ willChange: "transform, opacity" }}
-          className="max-w-xl p-10 rounded-3xl bg-background/60 backdrop-blur-xl border border-border/50 shadow-2xl"
+          className={`max-w-xl p-10 ${GLASS_CARD}`}
         >
           <img
             src={logo}

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -7,6 +7,8 @@ export const BTN =
   "inline-flex items-center justify-center rounded-md px-4 py-2 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 export const BTN_GHOST_ICON =
   "text-foreground hover:bg-foreground/10 focus-visible:ring-2 focus-visible:ring-accent rounded-md";
+export const GLASS_CARD =
+  "rounded-3xl bg-background/60 backdrop-blur-xl border border-border/50 shadow-2xl";
 export const T_PRIMARY = "text-foreground";
 export const T_MUTED = "text-foreground/70";
 export const T_SUBTLE = "text-foreground/50";


### PR DESCRIPTION
## Summary
- add `GLASS_CARD` utility class for reusable glassmorphic surfaces
- apply `GLASS_CARD` token to landing page hero card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a233986748329b37c0e9322946bf9