### PR TITLE
feat: add deletion and map preview to spot cards

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -14,7 +14,8 @@ type Action =
   | { type: "setPrefs"; prefs: Partial<Prefs> }
   | { type: "setAlerts"; alerts: Partial<Alerts> }
   | { type: "addSpot"; spot: Spot }
-  | { type: "updateSpot"; spot: Spot };
+  | { type: "updateSpot"; spot: Spot }
+  | { type: "removeSpot"; id: number };
 
 const initialState: AppState = {
   prefs: { units: "métriques", theme: "auto", gps: true, lang: "fr" },
@@ -34,6 +35,11 @@ function reducer(state: AppState, action: Action): AppState {
       return {
         ...state,
         mySpots: state.mySpots.map((s) => (s.id === action.spot.id ? action.spot : s)),
+      };
+    case "removeSpot":
+      return {
+        ...state,
+        mySpots: state.mySpots.filter((s) => s.id !== action.id),
       };
     default:
       return state;

--- a/src/i18n/common.ts
+++ b/src/i18n/common.ts
@@ -57,6 +57,7 @@ export default {
   "Note": { fr: "Note", en: "Rating" },
   "Champignons trouvés": { fr: "Champignons trouvés", en: "Found mushrooms" },
   "supprimer": { fr: "supprimer", en: "remove" },
+  "Supprimer ce coin ?": { fr: "Supprimer ce coin ?", en: "Delete this spot?" },
   "Ajouter un champignon…": { fr: "Ajouter un champignon…", en: "Add a mushroom…" },
   "Dernière visite": { fr: "Dernière visite", en: "Last visit" },
   "Photos": { fr: "Photos", en: "Photos" },

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -4,3 +4,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 export async function loadMap() {
   return maplibregl;
 }
+
+export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 160, zoom = 13) {
+  return `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lng}&zoom=${zoom}&size=${width}x${height}`;
+}


### PR DESCRIPTION
## Summary
- replace spot card photo with static map preview and central logo
- remove edit button, add delete cross with confirmation
- allow editing or deleting spots from the details modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a235b19d08329bfa062d822a70661