### PR TITLE
Enable location geocoding in map search

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -9,7 +9,7 @@ import { LEGEND } from "../data/legend";
 import { classNames } from "../utils";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
 import logo from "@/assets/logo.png";
-import { loadMap } from "@/services/openstreetmap";
+import { loadMap, geocode } from "@/services/openstreetmap";
 import { useT } from "../i18n";
 import type { Zone } from "../types";
 
@@ -20,6 +20,14 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
   const { t } = useT();
   const [selected, setSelected] = useState<string[]>([]);
   const [search, setSearch] = useState("");
+  const handleGeocode = async () => {
+    if (!search) return;
+    const res = await geocode(search);
+    const loc = res[0];
+    if (loc && mapRef.current) {
+      mapRef.current.flyTo({ center: [loc.lon, loc.lat], zoom: 12 });
+    }
+  };
   const results = useMemo(
     () =>
       search
@@ -123,6 +131,11 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
           <Input
             value={search}
             onChange={e => setSearch(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") {
+                handleGeocode();
+              }
+            }}
             placeholder={t("Rechercher un lieu…")}
             className={`pl-9 bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
           />

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -8,3 +8,19 @@ export async function loadMap() {
 export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 160, zoom = 13) {
   return `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lng}&zoom=${zoom}&size=${width}x${height}`;
 }
+
+export async function geocode(query: string) {
+  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.map((d: any) => ({
+      lat: parseFloat(d.lat),
+      lon: parseFloat(d.lon),
+      name: d.display_name,
+    }));
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add Nominatim geocoder helper
- allow map search input to geocode a typed location and fly the map to the first result

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a25edab008329b3c36691f1347177