### PR TITLE
feat: display nearest place name for map clicks

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -9,7 +9,7 @@ import { LEGEND } from "../data/legend";
 import { classNames } from "../utils";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED } from "../styles/tokens";
 import logo from "@/assets/logo.png";
-import { loadMap, geocode } from "@/services/openstreetmap";
+import { loadMap, geocode, reverseGeocode } from "@/services/openstreetmap";
 import { useT } from "../i18n";
 import type { Zone } from "../types";
 
@@ -68,7 +68,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
       const canvas = map.getCanvas();
       canvas.style.cursor = `url(${logo}) 16 16, auto`;
 
-      map.on("click", (e: any) => {
+      map.on("click", async (e: any) => {
         const { lat, lng } = e.lngLat;
 
         // Drop a temporary logo marker at the clicked location
@@ -110,7 +110,9 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
               return `${name} ${sc}%`;
             })
             .join("\n");
-          const msg = `${nearest.name}\n${nearest.score}% ${nearest.trend}\n${speciesLines}`;
+          const placeName = await reverseGeocode(lat, lng);
+          const title = placeName || nearest.name;
+          const msg = `${title}\n${nearest.score}% ${nearest.trend}\n${speciesLines}`;
           showToast(msg);
         }
       });

--- a/src/services/openstreetmap.test.ts
+++ b/src/services/openstreetmap.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('maplibre-gl', () => ({}));
+import { reverseGeocode } from './openstreetmap';
+
+describe('reverseGeocode', () => {
+  it('returns nearest place name', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ address: { village: 'Renage' } })
+    } as any);
+    vi.stubGlobal('fetch', fetchMock);
+    const name = await reverseGeocode(45, 5);
+    expect(name).toBe('Renage');
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null on error', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network'));
+    vi.stubGlobal('fetch', fetchMock);
+    const name = await reverseGeocode(0, 0);
+    expect(name).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -24,3 +24,25 @@ export async function geocode(query: string) {
     return [];
   }
 }
+
+export async function reverseGeocode(lat: number, lon: number) {
+  const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const addr = data.address || {};
+    return (
+      addr.hamlet ||
+      addr.village ||
+      addr.town ||
+      addr.city ||
+      addr.locality ||
+      addr.county ||
+      data.display_name ||
+      null
+    );
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- reverse geocode click location to find closest place name
- show found name in map toast instead of zone label
- add tests for reverse geocoder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a276978d88329891657a839e01b83