### PR TITLE
feat: add confirm modal for deleting spots

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui/button";
+import { T_PRIMARY } from "../styles/tokens";
+
+interface ConfirmModalProps {
+  open: boolean;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({
+  open,
+  message,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <div className={`mb-4 ${T_PRIMARY}`}>{message}</div>
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={onCancel}>
+          {cancelLabel}
+        </Button>
+        <Button variant="destructive" onClick={onConfirm}>
+          {confirmLabel}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default ConfirmModal;

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -9,6 +9,7 @@ import { loadMap } from "@/services/openstreetmap";
 import Logo from "@/assets/logo.png";
 import { useAppContext } from "../context/AppContext";
 import { EditSpotModal } from "./EditSpotModal";
+import { ConfirmModal } from "./ConfirmModal";
 
 export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -20,6 +21,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
   const { t } = useT();
   const { dispatch } = useAppContext();
   const [editing, setEditing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<any>(null);
 
@@ -52,10 +54,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
   };
 
   const handleDelete = () => {
-    if (window.confirm(t("Supprimer ce coin ?"))) {
-      dispatch({ type: "removeSpot", id: spot.id });
-      onClose();
-    }
+    setConfirmDelete(true);
   };
 
   return (
@@ -162,6 +161,18 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
           }}
         />
       )}
+      <ConfirmModal
+        open={confirmDelete}
+        message={t("Supprimer ce coin ?")}
+        confirmLabel={t("supprimer")}
+        cancelLabel={t("Annuler")}
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          dispatch({ type: "removeSpot", id: spot.id });
+          setConfirmDelete(false);
+          onClose();
+        }}
+      />
     </div>
   );
 }

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { CreateSpotModal } from "../components/CreateSpotModal";
 import { SpotDetailsModal } from "../components/SpotDetailsModal";
+import { ConfirmModal } from "../components/ConfirmModal";
 import { useAppContext } from "../context/AppContext";
 import { useT } from "../i18n";
 import { getStaticMapUrl } from "../services/openstreetmap";
@@ -18,6 +19,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
   const spots = state.mySpots;
   const [createOpen, setCreateOpen] = useState(false);
   const [details, setDetails] = useState<Spot | null>(null);
+  const [toDelete, setToDelete] = useState<Spot | null>(null);
   const [loading, setLoading] = useState(true);
   const { t } = useT();
 
@@ -90,11 +92,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
                   )}
                 </button>
                 <button
-                  onClick={() => {
-                    if (window.confirm(t("Supprimer ce coin ?"))) {
-                      dispatch({ type: "removeSpot", id: s.id });
-                    }
-                  }}
+                  onClick={() => setToDelete(s)}
                   className="absolute top-2 right-2 bg-secondary/80 hover:bg-secondary/80 dark:bg-secondary/80 dark:hover:bg-secondary/80 border border-secondary dark:border-secondary rounded-full p-2"
                   aria-label={t("supprimer")}
                 >
@@ -136,6 +134,19 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
 
       {details && (
         <SpotDetailsModal spot={details} onClose={() => setDetails(null)} />
+      )}
+      {toDelete && (
+        <ConfirmModal
+          open={!!toDelete}
+          message={t("Supprimer ce coin ?")}
+          confirmLabel={t("supprimer")}
+          cancelLabel={t("Annuler")}
+          onCancel={() => setToDelete(null)}
+          onConfirm={() => {
+            dispatch({ type: "removeSpot", id: toDelete.id });
+            setToDelete(null);
+          }}
+        />
       )}
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- add reusable `ConfirmModal` component
- use `ConfirmModal` when deleting spots from list or details view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a284c999083299d5baf70d7a160ba