### PR TITLE
Handle map thumbnail failures with placeholder

### DIFF
--- a/src/assets/map-placeholder.svg
+++ b/src/assets/map-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="160" viewBox="0 0 400 160">
+  <rect width="400" height="160" fill="#e5e5e5"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#666" font-size="20" font-family="sans-serif">Map unavailable</text>
+</svg>

--- a/src/images.d.ts
+++ b/src/images.d.ts
@@ -2,3 +2,8 @@ declare module '*.png' {
   const value: string;
   export default value;
 }
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -11,6 +11,7 @@ import { useAppContext } from "../context/AppContext";
 import { useT } from "../i18n";
 import { getStaticMapUrl } from "../services/openstreetmap";
 import Logo from "@/assets/logo.png";
+import MapPlaceholder from "@/assets/map-placeholder.svg";
 import type { Spot } from "../types";
 
 export default function SpotsScene({ onBack }: { onBack: () => void }) {
@@ -82,11 +83,23 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
                 <button onClick={() => setDetails(s)} className="block text-left">
                   {hasLoc ? (
                     <div className="relative w-full h-40">
-                      <img src={mapUrl as string} className="w-full h-full object-cover" />
+                      <img
+                        src={mapUrl as string}
+                        className="w-full h-full object-cover"
+                        onError={(e) => {
+                          e.currentTarget.src = MapPlaceholder;
+                        }}
+                      />
                       <img src={Logo} className="w-6 h-6 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
                     </div>
                   ) : (
-                    <img src={mapUrl as string} className="w-full h-40 object-cover" />
+                    <img
+                      src={mapUrl as string}
+                      className="w-full h-40 object-cover"
+                      onError={(e) => {
+                        e.currentTarget.src = MapPlaceholder;
+                      }}
+                    />
                   )}
                 </button>
                 <button


### PR DESCRIPTION
## Summary
- show a placeholder image when static map tiles fail to load in spot thumbnails
- allow importing SVG assets for the placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a281fd5048329997b61ecaaa33b12