### PR TITLE
Use OSM tile server for static map previews

### DIFF
--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -6,7 +6,17 @@ export async function loadMap() {
 }
 
 export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 160, zoom = 13) {
-  return `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lng}&zoom=${zoom}&size=${width}x${height}`;
+  // StaticMap from staticmap.openstreetmap.de sometimes returns 403 depending
+  // on the execution environment. To avoid relying on that service, build a
+  // URL pointing directly to the OpenStreetMap tile server. We compute the
+  // tile x/y for the given lat/lng and zoom. The returned tile is 256×256px
+  // and will be scaled by the caller via CSS.
+  const xtile = Math.floor(((lng + 180) / 360) * Math.pow(2, zoom));
+  const ytile = Math.floor(
+    ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
+      Math.pow(2, zoom)
+  );
+  return `https://tile.openstreetmap.org/${zoom}/${xtile}/${ytile}.png`;
 }
 
 export async function geocode(query: string) {


### PR DESCRIPTION
## Summary
- Build static map URLs with the public tile.openstreetmap.org server to avoid 403 responses from staticmap.openstreetmap.de

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a29a2a23c832981e093c47f2eb19f