### PR TITLE
feat: add custom delete confirmation

### DIFF
--- a/src/components/ConfirmDeleteModal.tsx
+++ b/src/components/ConfirmDeleteModal.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import { BTN, T_PRIMARY } from "../styles/tokens";
+import { useT } from "../i18n";
+
+export function ConfirmDeleteModal({ open, onConfirm, onCancel }: { open: boolean; onConfirm: () => void; onCancel: () => void }) {
+  const { t } = useT();
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <div className="space-y-4">
+        <p className={`text-center ${T_PRIMARY}`}>{t("Supprimer ce coin ?")}</p>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="ghost"
+            onClick={onCancel}
+            className={`rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}
+          >
+            {t("Annuler")}
+          </Button>
+          <Button variant="destructive" onClick={onConfirm} className={BTN}>
+            {t("Supprimer")}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/SpotDetailsModal.tsx
+++ b/src/components/SpotDetailsModal.tsx
@@ -9,6 +9,7 @@ import { loadMap } from "@/services/openstreetmap";
 import Logo from "@/assets/logo.png";
 import { useAppContext } from "../context/AppContext";
 import { EditSpotModal } from "./EditSpotModal";
+import { ConfirmDeleteModal } from "./ConfirmDeleteModal";
 
 export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () => void }) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -20,6 +21,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
   const { t } = useT();
   const { dispatch } = useAppContext();
   const [editing, setEditing] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<any>(null);
 
@@ -52,10 +54,7 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
   };
 
   const handleDelete = () => {
-    if (window.confirm(t("Supprimer ce coin ?"))) {
-      dispatch({ type: "removeSpot", id: spot.id });
-      onClose();
-    }
+    setConfirmOpen(true);
   };
 
   return (
@@ -162,6 +161,15 @@ export function SpotDetailsModal({ spot, onClose }: { spot: Spot; onClose: () =>
           }}
         />
       )}
+      <ConfirmDeleteModal
+        open={confirmOpen}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => {
+          dispatch({ type: "removeSpot", id: spot.id });
+          setConfirmOpen(false);
+          onClose();
+        }}
+      />
     </div>
   );
 }

--- a/src/i18n/common.ts
+++ b/src/i18n/common.ts
@@ -57,6 +57,7 @@ export default {
   "Note": { fr: "Note", en: "Rating" },
   "Champignons trouvés": { fr: "Champignons trouvés", en: "Found mushrooms" },
   "supprimer": { fr: "supprimer", en: "remove" },
+  "Supprimer": { fr: "Supprimer", en: "Delete" },
   "Supprimer ce coin ?": { fr: "Supprimer ce coin ?", en: "Delete this spot?" },
   "Ajouter un champignon…": { fr: "Ajouter un champignon…", en: "Add a mushroom…" },
   "Dernière visite": { fr: "Dernière visite", en: "Last visit" },

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { CreateSpotModal } from "../components/CreateSpotModal";
 import { SpotDetailsModal } from "../components/SpotDetailsModal";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 import { useAppContext } from "../context/AppContext";
 import { useT } from "../i18n";
 import { getStaticMapUrl } from "../services/openstreetmap";
@@ -19,6 +20,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
   const [createOpen, setCreateOpen] = useState(false);
   const [details, setDetails] = useState<Spot | null>(null);
   const [loading, setLoading] = useState(true);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
   const { t } = useT();
 
   const openRoute = (spot: Spot) => {
@@ -94,9 +96,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (window.confirm(t("Supprimer ce coin ?"))) {
-                      dispatch({ type: "removeSpot", id: s.id });
-                    }
+                    setDeleteId(s.id);
                   }}
                   className="absolute top-2 right-2 bg-secondary/80 hover:bg-secondary/80 dark:bg-secondary/80 dark:hover:bg-secondary/80 border border-secondary dark:border-secondary rounded-full p-2"
                   aria-label={t("supprimer")}
@@ -146,6 +146,15 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
       {details && (
         <SpotDetailsModal spot={details} onClose={() => setDetails(null)} />
       )}
+
+      <ConfirmDeleteModal
+        open={deleteId !== null}
+        onCancel={() => setDeleteId(null)}
+        onConfirm={() => {
+          if (deleteId) dispatch({ type: "removeSpot", id: deleteId });
+          setDeleteId(null);
+        }}
+      />
     </motion.section>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable confirm modal for spot deletions
- replace window confirm prompts with new modal in SpotsScene and SpotDetailsModal
- add translation key for "Supprimer"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a29e1173c8329ae0445e0c24a5f43