### PR TITLE
Improve StatsStack popup positioning and animations

### DIFF
--- a/src/components/StatsStack.tsx
+++ b/src/components/StatsStack.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Card, CardContent } from "./ui/card";
 import { Button } from "./ui/button";
 
@@ -28,17 +29,28 @@ export function StatsStack() {
   };
 
   return (
-    <div>
+    <div className="min-h-40">
       <Button onClick={addItem}>Ajouter une carte</Button>
-      <div className="mt-4 flex flex-col gap-2">
-        {items.map((item, idx) => (
-          <Card key={idx} data-testid="stat-card">
-            <CardContent className="flex justify-between">
-              <span className="font-semibold">{item.label}</span>
-              <span className={item.down ? "text-danger" : ""}>{item.percent}</span>
-            </CardContent>
-          </Card>
-        ))}
+      <div className="fixed bottom-4 left-4 flex flex-col gap-2">
+        <AnimatePresence>
+          {items.map((item, idx) => (
+            <motion.div
+              key={idx}
+              layout
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 20 }}
+              transition={{ duration: 0.25 }}
+            >
+              <Card data-testid="stat-card">
+                <CardContent className="flex justify-between">
+                  <span className="font-semibold">{item.label}</span>
+                  <span className={item.down ? "text-danger" : ""}>{item.percent}</span>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/src/components/__tests__/StatsStack.test.tsx
+++ b/src/components/__tests__/StatsStack.test.tsx
@@ -1,16 +1,16 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { StatsStack } from "../StatsStack";
 
 describe("StatsStack", () => {
-  it("stacks at most three cards", () => {
+  it("stacks at most three cards", async () => {
     render(<StatsStack />);
     const button = screen.getByRole("button", { name: /ajouter une carte/i });
     fireEvent.click(button);
     fireEvent.click(button);
     fireEvent.click(button);
     fireEvent.click(button);
-    expect(screen.getAllByTestId("stat-card")).toHaveLength(3);
+    await waitFor(() => expect(screen.getAllByTestId("stat-card")).toHaveLength(3));
   });
 });


### PR DESCRIPTION
## Summary
- Position stat popups near the bottom of the screen
- Animate appearance, movement, and removal using framer-motion
- Adjust test to account for animated transitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2ab617448329b7cd812f4806b140