### PR TITLE
Remove glass panel from landing scene

### DIFF
--- a/src/scenes/LandingScene.tsx
+++ b/src/scenes/LandingScene.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { BTN, BTN_GHOST_ICON, GLASS_CARD, T_MUTED } from "../styles/tokens";
+import { BTN, BTN_GHOST_ICON, T_MUTED } from "../styles/tokens";
 import { useT } from "../i18n";
 import logo from "@/assets/logo.png";
 
@@ -59,7 +59,7 @@ export default function LandingScene({
           animate={{ y: 0, opacity: 1 }}
           transition={{ delay: 0.2 }}
           style={{ willChange: "transform, opacity" }}
-          className={`max-w-xl p-10 ${GLASS_CARD}`}
+          className="max-w-xl p-10"
         >
           <img
             src={logo}

--- a/src/scenes/__tests__/LandingScene.test.tsx
+++ b/src/scenes/__tests__/LandingScene.test.tsx
@@ -50,10 +50,11 @@ describe('LandingScene', () => {
     expect(secondary![0].animate).toMatchObject({ rotate: expect.any(Array) });
   });
 
-  it('shows glassmorphic card with animated content', () => {
+  it('shows card with animated content', () => {
     renderScene();
-    const card = motionDiv.mock.calls.find(([props]) => props.className?.includes('backdrop-blur-xl'));
+    const card = motionDiv.mock.calls.find(([props]) => props.className?.includes('max-w-xl'));
     expect(card).toBeTruthy();
+    expect(card![0].className).not.toContain('backdrop-blur-xl');
     expect(card![0].initial).toEqual({ y: 20, opacity: 0 });
     expect(card![0].animate).toEqual({ y: 0, opacity: 1 });
     expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- remove glassmorphic styling from landing scene card
- adjust landing scene test for non-glass card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2a5d501083298ec0eedd6a2cccb4