### PR TITLE
Capture high-quality map thumbnails

### DIFF
--- a/src/components/__tests__/CreateSpotModal.test.tsx
+++ b/src/components/__tests__/CreateSpotModal.test.tsx
@@ -17,6 +17,12 @@ vi.mock('@/services/openstreetmap', () => ({
       getCenter() {
         return { lat: 0, lng: 0 };
       }
+      scrollZoom = { disable: vi.fn() };
+      doubleClickZoom = { disable: vi.fn() };
+      touchZoomRotate = { disable: vi.fn() };
+      getCanvas() {
+        return { toDataURL: vi.fn(() => 'data:image/png;base64,test') };
+      }
     },
   })),
 }));

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -78,7 +78,8 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
           spots.map(s => {
             const [lat, lng] = s.location ? s.location.split(",").map(v => parseFloat(v.trim())) : [NaN, NaN];
             const hasLoc = !Number.isNaN(lat) && !Number.isNaN(lng);
-            const mapUrl = hasLoc ? getStaticMapUrl(lat, lng) : s.cover || s.photos?.[0];
+            const useCover = Boolean(s.cover);
+            const mapUrl = s.cover || (hasLoc ? getStaticMapUrl(lat, lng) : s.photos?.[0]);
             return (
               <Card
                 key={s.id}
@@ -88,7 +89,9 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
                 {hasLoc ? (
                   <div className="relative w-full h-40">
                     <img src={mapUrl as string} className="w-full h-full object-cover" />
-                    <img src={Logo} className="w-6 h-6 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
+                    {!useCover && (
+                      <img src={Logo} className="w-6 h-6 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
+                    )}
                   </div>
                 ) : (
                   <img src={mapUrl as string} className="w-full h-40 object-cover" />

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -9,14 +9,15 @@ export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 
   // StaticMap from staticmap.openstreetmap.de sometimes returns 403 depending
   // on the execution environment. To avoid relying on that service, build a
   // URL pointing directly to the OpenStreetMap tile server. We compute the
-  // tile x/y for the given lat/lng and zoom. The returned tile is 256×256px
-  // and will be scaled by the caller via CSS.
+  // tile x/y for the given lat/lng and zoom. To reduce pixelation we request
+  // the "@2x" high‑resolution variant of the tile (512×512px) which will then
+  // be downscaled by the caller via CSS.
   const xtile = Math.floor(((lng + 180) / 360) * Math.pow(2, zoom));
   const ytile = Math.floor(
     ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
       Math.pow(2, zoom)
   );
-  return `https://tile.openstreetmap.org/${zoom}/${xtile}/${ytile}.png`;
+  return `https://tile.openstreetmap.org/${zoom}/${xtile}/${ytile}@2x.png`;
 }
 
 export async function geocode(query: string) {


### PR DESCRIPTION
## Summary
- capture map screenshot for new spots and enforce constant zoom using OpenStreetMap tiles
- use saved screenshot for spot cards and only overlay pin when needed
- request high-resolution @2x tiles when falling back to static map URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a363226a88329a92d9f3c98a0599d