### PR TITLE
feat: open zone dashboard from stats notifications

### DIFF
--- a/src/components/StatsStack.tsx
+++ b/src/components/StatsStack.tsx
@@ -2,23 +2,50 @@ import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Card, CardContent } from "./ui/card";
 import { Button } from "./ui/button";
+import ZoneDashboard from "./ZoneDashboard";
+import type { Zone } from "../types";
 
-type StatItem = {
-  label: string;
-  percent: string;
-  down?: boolean;
-};
+type StatItem = Zone;
 
 const data: StatItem[] = [
-  { label: "Ripisylve du Vieux Pont", percent: "72% ⬊", down: true },
-  { label: "Cèpe", percent: "40%" },
-  { label: "Girolle", percent: "55%" },
-  { label: "Morille", percent: "85%" }
+  {
+    id: "la_vrignaie",
+    name: "La Vrignaie",
+    score: 72,
+    species: { cepe: 40, girolle: 55, morille: 85 },
+    trend: "down",
+    coords: [0, 0]
+  },
+  {
+    id: "bois_joli",
+    name: "Bois Joli",
+    score: 60,
+    species: { cepe: 30, girolle: 50, morille: 40 },
+    trend: "up",
+    coords: [0, 0]
+  },
+  {
+    id: "ripisylve",
+    name: "Ripisylve du Vieux Pont",
+    score: 68,
+    species: { cepe: 35, girolle: 60, morille: 80 },
+    trend: "down",
+    coords: [0, 0]
+  },
+  {
+    id: "foret_pins",
+    name: "Forêt des Pins",
+    score: 80,
+    species: { cepe: 70, girolle: 40, morille: 20 },
+    trend: "up",
+    coords: [0, 0]
+  }
 ];
 
 export function StatsStack() {
   const [items, setItems] = useState<StatItem[]>([]);
   const [index, setIndex] = useState(0);
+  const [selected, setSelected] = useState<StatItem | null>(null);
 
   const addItem = () => {
     setItems(prev => {
@@ -42,16 +69,27 @@ export function StatsStack() {
               exit={{ opacity: 0, y: 20 }}
               transition={{ duration: 0.25 }}
             >
-              <Card data-testid="stat-card">
+              <Card data-testid="stat-card" onClick={() => setSelected(item)} className="cursor-pointer">
                 <CardContent className="flex justify-between">
-                  <span className="font-semibold">{item.label}</span>
-                  <span className={item.down ? "text-danger" : ""}>{item.percent}</span>
+                  <span className="font-semibold">{item.name}</span>
+                  <span className={item.trend === "down" ? "text-danger" : ""}>
+                    {item.score}% {item.trend === "down" ? "⬊" : ""}
+                  </span>
                 </CardContent>
               </Card>
             </motion.div>
           ))}
         </AnimatePresence>
       </div>
+      {selected && (
+        <ZoneDashboard
+          zone={selected}
+          onGo={() => {}}
+          onAdd={() => {}}
+          onOpenShroom={() => {}}
+          onClose={() => setSelected(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ZoneDashboard.tsx
+++ b/src/components/ZoneDashboard.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo } from "react";
+import { motion } from "framer-motion";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine } from "recharts";
+import type { Zone } from "../types";
+import { generateForecast } from "../utils";
+
+interface Props {
+  zone: Zone;
+  onGo: () => void;
+  onAdd: () => void;
+  onOpenShroom: (id: string) => void;
+  onClose: () => void;
+}
+
+export default function ZoneDashboard({ zone, onGo, onAdd, onOpenShroom, onClose }: Props) {
+  const data = useMemo(() => generateForecast("fr"), [zone?.id]);
+  if (!zone) return null;
+
+  return (
+    <motion.section
+      initial={{ x: 20, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: -20, opacity: 0 }}
+      className="fixed inset-0 z-50 p-3 bg-background/80 backdrop-blur-sm overflow-auto grid place-items-center"
+    >
+      <div className="rounded-2xl border bg-paper text-foreground overflow-hidden w-full max-w-xl">
+        <div className="p-4 border-b flex items-center justify-between gap-2">
+          <div className="text-base font-medium">{zone.name}</div>
+          <span className="inline-flex items-center px-2 py-0.5 text-sm rounded-full border">
+            {zone.score}%
+          </span>
+        </div>
+        <div className="p-4">
+          <div className="h-56">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+                <XAxis dataKey="day" tick={{ fontSize: 10 }} interval={3} />
+                <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} width={28} />
+                <Tooltip />
+                <ReferenceLine x={data[7].day} strokeDasharray="3 3" />
+                <Line type="monotone" dataKey="score" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-2 text-xs">Icônes météo (démo)</div>
+          <div className="mt-4">
+            <div className="text-sm mb-2">Comestibles probables</div>
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(zone.species)
+                .filter(([, v]) => v > 0)
+                .map(([id, sc]) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => onOpenShroom(id)}
+                    className="rounded-xl border p-2 text-left"
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="w-12 h-12 rounded-lg border overflow-hidden grid place-items-center text-xs">
+                        img
+                      </div>
+                      <div>
+                        <div className="text-sm font-medium">{labelFromId(id)}</div>
+                        <div className="text-xs">Score {sc}%</div>
+                      </div>
+                    </div>
+                  </button>
+                ))}
+            </div>
+          </div>
+          <div className="mt-4 flex items-center gap-2">
+            <button type="button" onClick={onGo} className="rounded-xl border px-3 py-2">
+              Y aller
+            </button>
+            <button type="button" onClick={onAdd} className="rounded-xl border px-3 py-2">
+              Ajouter à mes coins
+            </button>
+            <button type="button" onClick={onClose} className="ml-auto rounded-xl border px-3 py-2">
+              Fermer
+            </button>
+          </div>
+          <p className="text-xs mt-2">
+            Prévisions locales hors‑ligne (7 jours) disponibles pour 3 champignons inclus.
+          </p>
+        </div>
+      </div>
+    </motion.section>
+  );
+}
+
+function labelFromId(id: string) {
+  const dict: Record<string, string> = {
+    cepe: "Cèpe",
+    girolle: "Girolle",
+    morille: "Morille",
+  };
+  return dict[id] || id;
+}

--- a/src/components/__tests__/StatsStack.test.tsx
+++ b/src/components/__tests__/StatsStack.test.tsx
@@ -3,6 +3,16 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { StatsStack } from "../StatsStack";
 
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver;
+});
+
 describe("StatsStack", () => {
   it("stacks at most three cards", async () => {
     render(<StatsStack />);
@@ -12,5 +22,14 @@ describe("StatsStack", () => {
     fireEvent.click(button);
     fireEvent.click(button);
     await waitFor(() => expect(screen.getAllByTestId("stat-card")).toHaveLength(3));
+  });
+
+  it("opens dashboard on card click", async () => {
+    render(<StatsStack />);
+    const button = screen.getByRole("button", { name: /ajouter une carte/i });
+    fireEvent.click(button);
+    const card = await screen.findByTestId("stat-card");
+    fireEvent.click(card);
+    await waitFor(() => expect(screen.getByText("Comestibles probables")).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Summary
- add ZoneDashboard component rendering forecast and species details
- make StatsStack cards open ZoneDashboard when clicked
- test StatsStack to cover dashboard activation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a378e772c8329a740b67e8346f735