### PR TITLE
fix: skip tailwind wasm in vitest

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,13 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
-  test: { environment: 'jsdom', globals: true },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    css: {
+      postcss: {
+        plugins: [],
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- disable PostCSS plugins during vitest to avoid Tailwind WASM memory errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a3976b6288329a639229d67f4b5a8