### PR TITLE
Revert high-resolution map thumbnail feature

### DIFF
--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
 import { X, Image } from "lucide-react";
-import type { StyleSpecification } from "maplibre-gl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
@@ -61,36 +60,12 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
   useEffect(() => {
     if (mapRef.current || !mapContainerRef.current) return;
     loadMap().then(maplibregl => {
-      const osmStyle: StyleSpecification = {
-        version: 8,
-        sources: {
-          osm: {
-            type: "raster",
-            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-            tileSize: 256,
-            attribution: "© OpenStreetMap contributors",
-          },
-        },
-        layers: [
-          {
-            id: "osm",
-            type: "raster",
-            source: "osm",
-            minzoom: 0,
-            maxzoom: 19,
-          },
-        ],
-      };
       const map = new maplibregl.Map({
         container: mapContainerRef.current as HTMLDivElement,
-        style: osmStyle,
+        style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
         center: [2.3522, 48.8566],
-        zoom: 13,
+        zoom: 10,
       });
-      // keep a constant zoom level for consistent screenshots
-      map.scrollZoom.disable();
-      map.doubleClickZoom.disable();
-      map.touchZoomRotate.disable();
       mapRef.current = map;
       map.on("load", () => map.resize());
 
@@ -113,15 +88,7 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
   };
 
   const create = () => {
-    let cover = photos[0];
-    if (!cover && mapRef.current) {
-      try {
-        cover = mapRef.current.getCanvas().toDataURL("image/png");
-      } catch {
-        cover = undefined;
-      }
-    }
-    cover = cover || MUSHROOMS[0].photo;
+    const cover = photos[0] || MUSHROOMS[0].photo;
     const history = [{ date: last, rating, note: t("Création"), photos: photos.slice(0, 3) }];
     onCreate({ id: Date.now(), name, species, rating, last, location, cover, photos: photos.length ? photos : [cover], history });
   };

--- a/src/components/__tests__/CreateSpotModal.test.tsx
+++ b/src/components/__tests__/CreateSpotModal.test.tsx
@@ -17,12 +17,6 @@ vi.mock('@/services/openstreetmap', () => ({
       getCenter() {
         return { lat: 0, lng: 0 };
       }
-      scrollZoom = { disable: vi.fn() };
-      doubleClickZoom = { disable: vi.fn() };
-      touchZoomRotate = { disable: vi.fn() };
-      getCanvas() {
-        return { toDataURL: vi.fn(() => 'data:image/png;base64,test') };
-      }
     },
   })),
 }));

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -78,8 +78,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
           spots.map(s => {
             const [lat, lng] = s.location ? s.location.split(",").map(v => parseFloat(v.trim())) : [NaN, NaN];
             const hasLoc = !Number.isNaN(lat) && !Number.isNaN(lng);
-            const useCover = Boolean(s.cover);
-            const mapUrl = s.cover || (hasLoc ? getStaticMapUrl(lat, lng) : s.photos?.[0]);
+            const mapUrl = hasLoc ? getStaticMapUrl(lat, lng) : s.cover || s.photos?.[0];
             return (
               <Card
                 key={s.id}
@@ -89,9 +88,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
                 {hasLoc ? (
                   <div className="relative w-full h-40">
                     <img src={mapUrl as string} className="w-full h-full object-cover" />
-                    {!useCover && (
-                      <img src={Logo} className="w-6 h-6 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
-                    )}
+                    <img src={Logo} className="w-6 h-6 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
                   </div>
                 ) : (
                   <img src={mapUrl as string} className="w-full h-40 object-cover" />

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -9,15 +9,14 @@ export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 
   // StaticMap from staticmap.openstreetmap.de sometimes returns 403 depending
   // on the execution environment. To avoid relying on that service, build a
   // URL pointing directly to the OpenStreetMap tile server. We compute the
-  // tile x/y for the given lat/lng and zoom. To reduce pixelation we request
-  // the "@2x" high‑resolution variant of the tile (512×512px) which will then
-  // be downscaled by the caller via CSS.
+  // tile x/y for the given lat/lng and zoom. The returned tile is 256×256px
+  // and will be scaled by the caller via CSS.
   const xtile = Math.floor(((lng + 180) / 360) * Math.pow(2, zoom));
   const ytile = Math.floor(
     ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
       Math.pow(2, zoom)
   );
-  return `https://tile.openstreetmap.org/${zoom}/${xtile}/${ytile}@2x.png`;
+  return `https://tile.openstreetmap.org/${zoom}/${xtile}/${ytile}.png`;
 }
 
 export async function geocode(query: string) {


### PR DESCRIPTION
## Summary
- Revert map screenshot feature in CreateSpotModal and restore original tile style
- Use standard-resolution static map tiles
- Remove related test adjustments and simplify map previews

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a3ba3a26083299d0ed6fb84545b31