### PR TITLE
fix: allow map notifications to open zones

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -37,12 +37,12 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
         : [],
     [search]
   );
-  type Toast = { id: number; text: string };
+  type Toast = { id: number; text: string; zone: Zone };
   const [toasts, setToasts] = useState<Toast[]>([]);
-  const showToast = (text: string) => {
+  const showToast = (text: string, zone: Zone) => {
     const id = Date.now() + Math.random();
     setToasts(curr => {
-      const next = [{ id, text }, ...curr];
+      const next = [{ id, text, zone }, ...curr];
       return next.slice(0, 3);
     });
     setTimeout(() => {
@@ -113,7 +113,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
           const placeName = await reverseGeocode(lat, lng);
           const title = placeName || nearest.name;
           const msg = `${title}\n${nearest.score}% ${nearest.trend}\n${speciesLines}`;
-          showToast(msg);
+          showToast(msg, nearest);
         }
       });
     });
@@ -199,12 +199,17 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
         {toasts.length > 0 && (
           <div className="absolute left-3 top-16 flex flex-col gap-2">
             {toasts.map(toast => (
-              <div
+              <button
                 key={toast.id}
-                className="bg-secondary/80 dark:bg-secondary/80 backdrop-blur rounded-xl p-2 border border-secondary dark:border-secondary"
+                type="button"
+                onClick={() => {
+                  onZone(toast.zone);
+                  setToasts(curr => curr.filter(t => t.id !== toast.id));
+                }}
+                className="bg-secondary/80 dark:bg-secondary/80 backdrop-blur rounded-xl p-2 border border-secondary dark:border-secondary text-left"
               >
                 <div className={`text-xs whitespace-pre-line ${T_PRIMARY}`}>{toast.text}</div>
-              </div>
+              </button>
             ))}
           </div>
         )}

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect } from 'vitest';
+
+import MapScene from '../MapScene';
+import { AppProvider } from '@/context/AppContext';
+import { DEMO_ZONES } from '../../data/zones';
+
+// Hoist mocks for framer-motion
+const { motionSection } = vi.hoisted(() => ({
+  motionSection: vi.fn((props: any) => <section {...props} />),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    section: motionSection,
+  },
+}));
+
+let mapInstance: any;
+
+// Mock OpenStreetMap services
+vi.mock('../../services/openstreetmap', () => {
+  class Map {
+    handlers: Record<string, any> = {};
+    constructor() {
+      mapInstance = this;
+    }
+    on(event: string, cb: any) {
+      this.handlers[event] = cb;
+    }
+    getCanvas() {
+      return { style: {} } as any;
+    }
+    flyTo() {}
+    remove() {}
+  }
+  class Marker {
+    constructor() {}
+    setLngLat() { return this; }
+    addTo() { return this; }
+    remove() {}
+  }
+  return {
+    loadMap: vi.fn(() => Promise.resolve({ Map, Marker })),
+    geocode: vi.fn(),
+    reverseGeocode: vi.fn(() => Promise.resolve('Testville')),
+  };
+});
+
+describe('MapScene', () => {
+  it('opens zone when toast is clicked', async () => {
+    const onZone = vi.fn();
+    render(
+      <AppProvider>
+        <MapScene onZone={onZone} gpsFollow={false} setGpsFollow={() => {}} onBack={() => {}} />
+      </AppProvider>
+    );
+
+    // Wait for map to initialize then simulate a click near a known zone
+    await new Promise(r => setTimeout(r, 0));
+    mapInstance.handlers.click({ lngLat: { lat: 45.7, lng: 5.9 } });
+
+    const toast = await screen.findByRole('button', { name: /Testville/ });
+    fireEvent.click(toast);
+
+    expect(onZone).toHaveBeenCalledWith(expect.objectContaining({ id: DEMO_ZONES[1].id }));
+  });
+});


### PR DESCRIPTION
## Summary
- make map toasts reference their zone and open its dashboard when clicked
- add regression test for clicking map toast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3ce73bd0832982ecbd5957e2e318