### PR TITLE
Show zone name in map toasts

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -111,8 +111,8 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
             })
             .join("\n");
           const placeName = await reverseGeocode(lat, lng);
-          const title = placeName || nearest.name;
-          const msg = `${title}\n${nearest.score}% ${nearest.trend}\n${speciesLines}`;
+          const locationLine = placeName ? `${placeName}\n` : "";
+          const msg = `${nearest.name}\n${locationLine}${nearest.score}% ${nearest.trend}\n${speciesLines}`;
           showToast(msg, nearest);
         }
       });

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -62,7 +62,9 @@ describe('MapScene', () => {
     await new Promise(r => setTimeout(r, 0));
     mapInstance.handlers.click({ lngLat: { lat: 45.7, lng: 5.9 } });
 
-    const toast = await screen.findByRole('button', { name: /Testville/ });
+    const toast = await screen.findByRole('button', { name: new RegExp(DEMO_ZONES[1].name) });
+    expect(toast).toHaveTextContent(DEMO_ZONES[1].name);
+    expect(toast).toHaveTextContent('Testville');
     fireEvent.click(toast);
 
     expect(onZone).toHaveBeenCalledWith(expect.objectContaining({ id: DEMO_ZONES[1].id }));


### PR DESCRIPTION
## Summary
- Display zone name at the top of map toasts and include reverse geocode info below
- Update MapScene test to search for zone name in toast
- Ensure MapScene toast shows both zone name and place name before opening the zone

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3f4e045483299160e239472430bc