### PR TITLE
Override toast zone name with reverse geocoded place

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -106,14 +106,16 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
         if (nearest) {
           const speciesLines = Object.entries(nearest.species)
             .map(([id, sc]) => {
-              const name = MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0] || id;
+              const name =
+                MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0] || id;
               return `${name} ${sc}%`;
             })
             .join("\n");
+
           const placeName = await reverseGeocode(lat, lng);
-          const locationLine = placeName ? `${placeName}\n` : "";
-          const msg = `${nearest.name}\n${locationLine}${nearest.score}% ${nearest.trend}\n${speciesLines}`;
-          showToast(msg, nearest);
+          const zone = placeName ? { ...nearest, name: placeName } : nearest;
+          const msg = `${zone.name}\n${zone.score}% ${zone.trend}\n${speciesLines}`;
+          showToast(msg, zone);
         }
       });
     });

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -62,9 +62,11 @@ describe('MapScene', () => {
     await new Promise(r => setTimeout(r, 0));
     mapInstance.handlers.click({ lngLat: { lat: 45.7, lng: 5.9 } });
 
-    const toast = await screen.findByRole('button', { name: new RegExp(DEMO_ZONES[1].name) });
+    const toast = await screen.findByRole('button', { name: /Testville/ });
     fireEvent.click(toast);
 
-    expect(onZone).toHaveBeenCalledWith(expect.objectContaining({ id: DEMO_ZONES[1].id }));
+    expect(onZone).toHaveBeenCalledWith(
+      expect.objectContaining({ id: DEMO_ZONES[1].id, name: 'Testville' })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Use reverse geocoded place name for toast text and zone title
- Update map scene test to expect overridden location name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a47b6c6b4832988d9965d75f09dc5