### PR TITLE
refactor: add modular settings hub

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# Example environment variables
+VITE_API_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -33,3 +33,19 @@ Run the dev server with:
 ```bash
 npm run dev
 ```
+
+## Settings Module
+
+The `/settings` route exposes account, subscription, offline maps, alerts,
+preferences and legal sections. Each section lives in
+`src/routes/settings/*.tsx` and shares state through `src/stores/settings.ts`
+persisted to `localStorage` with Zustand.
+
+Forms rely on `react-hook-form` and Zod schemas under `src/validation`. Mocked
+API helpers are in `src/api`. To extend, add new slice in the store and a
+corresponding component under `src/routes/settings`.
+
+Environment variables can be defined in `.env` (see `.env.sample`).
+
+Limitations: offline map downloads and background sync are simplified mocks and
+should be replaced by real implementations when integrating a backend.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,17 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.0",
         "framer-motion": "^10.18.0",
         "lucide-react": "^0.311.0",
         "maplibre-gl": "^5.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.51.3",
         "react-router-dom": "^7.8.0",
-        "recharts": "^2.8.0"
+        "recharts": "^2.8.0",
+        "zod": "^3.23.8",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.11",
@@ -992,6 +996,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -2019,14 +2032,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3832,6 +3845,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -4486,6 +4515,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -4846,6 +4884,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.8.0",
-    "recharts": "^2.8.0"
+    "recharts": "^2.8.0",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8",
+    "react-hook-form": "^7.51.3",
+    "@hookform/resolvers": "^3.3.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import ZoneScene from "./scenes/ZoneScene";
 import SpotsScene from "./scenes/SpotsScene";
 import PickerScene from "./scenes/PickerScene";
 import MushroomScene from "./scenes/MushroomScene";
-import SettingsScene from "./scenes/SettingsScene";
+import SettingsIndex from "./routes/settings";
 import DownloadScene from "./scenes/DownloadScene";
 import PrivacyPolicyScene from "./scenes/PrivacyPolicyScene";
 import TermsScene from "./scenes/TermsScene";
@@ -20,6 +20,7 @@ import SignupScene from "./scenes/SignupScene";
 import PremiumScene from "./scenes/PremiumScene";
 import { AppProvider, useAppContext } from "./context/AppContext";
 import { AuthProvider } from "./context/AuthContext";
+import { ToastProvider } from "./components/settings/Toasts";
 import { useT } from "./i18n";
 import { Scene } from "./routes";
 
@@ -27,7 +28,9 @@ export default function MycoExplorerApp() {
   return (
     <AuthProvider>
       <AppProvider>
-        <AppContent />
+        <ToastProvider>
+          <AppContent />
+        </ToastProvider>
       </AppProvider>
     </AuthProvider>
   );
@@ -190,20 +193,7 @@ function AppContent() {
               path={Scene.Mushroom}
               element={<MushroomScene item={selectedMushroom} onSeeZones={() => goTo(Scene.Map)} onBack={goBack} />}
             />
-            <Route
-              path={Scene.Settings}
-              element={
-                <SettingsScene
-                  onOpenPacks={() => goTo(Scene.Download)}
-                  onOpenPrivacy={() => goTo(Scene.Privacy)}
-                  onOpenTerms={() => goTo(Scene.Terms)}
-                  onLogin={() => goTo(Scene.Login)}
-                  onSignup={() => goTo(Scene.Signup)}
-                  onPremium={() => goTo(Scene.Premium)}
-                  onBack={goBack}
-                />
-              }
-            />
+            <Route path={Scene.Settings} element={<SettingsIndex />} />
             <Route
               path={Scene.Download}
               element={

--- a/src/api/alerts.ts
+++ b/src/api/alerts.ts
@@ -1,0 +1,9 @@
+export type AlertSettings = {
+  optimum: boolean;
+  newZone: boolean;
+};
+
+export async function saveAlerts(alerts: AlertSettings): Promise<AlertSettings> {
+  await new Promise((r) => setTimeout(r, 200));
+  return alerts;
+}

--- a/src/api/maps.ts
+++ b/src/api/maps.ts
@@ -1,0 +1,19 @@
+export type DownloadJob = {
+  id: string;
+  name: string;
+  radiusKm: number;
+  progress: number;
+  status: 'queued' | 'downloading' | 'paused' | 'done' | 'error';
+};
+
+const jobs: DownloadJob[] = [];
+
+export async function enqueue(job: Omit<DownloadJob, 'progress' | 'status'>): Promise<DownloadJob> {
+  const j: DownloadJob = { ...job, progress: 0, status: 'queued' };
+  jobs.push(j);
+  return j;
+}
+
+export function listJobs(): Promise<DownloadJob[]> {
+  return Promise.resolve(jobs);
+}

--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -1,0 +1,14 @@
+export type SubscriptionStatus = {
+  status: 'free' | 'premium';
+  renewalDate?: string;
+};
+
+export async function fetchSubscription(): Promise<SubscriptionStatus> {
+  await new Promise((r) => setTimeout(r, 300));
+  return { status: 'free' };
+}
+
+export async function upgrade(): Promise<SubscriptionStatus> {
+  await new Promise((r) => setTimeout(r, 300));
+  return { status: 'premium', renewalDate: new Date().toISOString() };
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,15 @@
+export type LoginPayload = { email: string; password: string };
+export type User = { email: string };
+
+export async function login(payload: LoginPayload): Promise<User> {
+  await new Promise((r) => setTimeout(r, 300));
+  return { email: payload.email };
+}
+
+export async function logout(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+export async function deleteAccount(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 500));
+}

--- a/src/components/settings/ConsentModal.tsx
+++ b/src/components/settings/ConsentModal.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+type Props = {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  message: string;
+};
+
+export const ConsentModal: React.FC<Props> = ({ open, onConfirm, onCancel, message }) => {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div className="bg-white p-4 rounded space-y-4">
+        <p>{message}</p>
+        <div className="flex gap-2 justify-end">
+          <button onClick={onCancel} className="px-2 py-1 border rounded">Annuler</button>
+          <button onClick={onConfirm} className="px-2 py-1 bg-blue-600 text-white rounded">OK</button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/settings/DangerZone.tsx
+++ b/src/components/settings/DangerZone.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+type Props = {
+  title: string;
+  description?: string;
+  actionLabel: string;
+  onAction: () => void;
+};
+
+export const DangerZone: React.FC<Props> = ({
+  title,
+  description,
+  actionLabel,
+  onAction,
+}) => (
+  <div className="border border-red-500 rounded p-4 bg-red-50">
+    <h3 className="font-bold text-red-700 mb-2">{title}</h3>
+    {description && <p className="text-sm mb-2">{description}</p>}
+    <button
+      type="button"
+      onClick={() => {
+        if (window.confirm(actionLabel)) onAction();
+      }}
+      className="px-3 py-2 bg-red-600 text-white rounded"
+    >
+      {actionLabel}
+    </button>
+  </div>
+);

--- a/src/components/settings/DownloadQueue.tsx
+++ b/src/components/settings/DownloadQueue.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+import { listJobs, DownloadJob } from '../../api/maps';
+
+export const DownloadQueue: React.FC = () => {
+  const [jobs, setJobs] = useState<DownloadJob[]>([]);
+  useEffect(() => {
+    listJobs().then(setJobs);
+  }, []);
+  if (!jobs.length) return <p>Aucun téléchargement</p>;
+  return (
+    <ul className="space-y-1">
+      {jobs.map((j) => (
+        <li key={j.id} className="text-sm">
+          {j.name} – {j.progress}%
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/components/settings/FileSizeBar.tsx
+++ b/src/components/settings/FileSizeBar.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type Props = {
+  used: number;
+  total: number;
+};
+
+export const FileSizeBar: React.FC<Props> = ({ used, total }) => {
+  const pct = total === 0 ? 0 : Math.min(100, Math.round((used / total) * 100));
+  return (
+    <div className="w-full bg-gray-200 h-2 rounded">
+      <div className="bg-blue-500 h-2 rounded" style={{ width: pct + '%' }} />
+    </div>
+  );
+};

--- a/src/components/settings/MapAreaPicker.tsx
+++ b/src/components/settings/MapAreaPicker.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import { NumberField } from './NumberField';
+
+type Props = {
+  onChange: (lat: number, lng: number, radiusKm: number) => void;
+};
+
+export const MapAreaPicker: React.FC<Props> = ({ onChange }) => {
+  const [lat, setLat] = useState(45.764); // Lyon
+  const [lng, setLng] = useState(4.8357);
+  const [radius, setRadius] = useState(10);
+  return (
+    <div className="space-y-2">
+      <NumberField label="Latitude" value={lat} onChange={(v) => { setLat(v); onChange(v, lng, radius); }} />
+      <NumberField label="Longitude" value={lng} onChange={(v) => { setLng(v); onChange(lat, v, radius); }} />
+      <NumberField label="Rayon (km)" value={radius} onChange={(v) => { setRadius(v); onChange(lat, lng, v); }} />
+    </div>
+  );
+};

--- a/src/components/settings/NumberField.tsx
+++ b/src/components/settings/NumberField.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+type Props = {
+  value: number;
+  onChange: (v: number) => void;
+  label: string;
+  id?: string;
+  min?: number;
+  max?: number;
+};
+
+export const NumberField: React.FC<Props> = ({
+  value,
+  onChange,
+  label,
+  id,
+  min,
+  max,
+}) => (
+  <label className="flex flex-col gap-1">
+    <span>{label}</span>
+    <input
+      type="number"
+      id={id}
+      value={value}
+      min={min}
+      max={max}
+      onChange={(e) => onChange(Number(e.target.value))}
+      className="border p-2 rounded"
+    />
+  </label>
+);

--- a/src/components/settings/Select.tsx
+++ b/src/components/settings/Select.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+type Option = { value: string; label: string };
+
+type Props = {
+  value: string;
+  onChange: (v: string) => void;
+  options: Option[];
+  label: string;
+  id?: string;
+};
+
+export const Select: React.FC<Props> = ({ value, onChange, options, label, id }) => (
+  <label className="flex flex-col gap-1">
+    <span>{label}</span>
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="border p-2 rounded"
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  </label>
+);

--- a/src/components/settings/Switch.tsx
+++ b/src/components/settings/Switch.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type Props = {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  id?: string;
+};
+
+export const Switch: React.FC<Props> = ({ checked, onChange, label, id }) => {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      id={id}
+      onClick={() => onChange(!checked)}
+      className={`px-3 py-2 rounded-full border ${
+        checked ? 'bg-green-500 text-white' : 'bg-gray-200'
+      } focus-visible:outline focus-visible:outline-2`}
+    >
+      {label}
+    </button>
+  );
+};

--- a/src/components/settings/Toasts.tsx
+++ b/src/components/settings/Toasts.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+type Toast = { id: number; message: string };
+
+type ToastContextValue = {
+  toasts: Toast[];
+  add: (message: string) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const add = (message: string) => {
+    const id = Date.now();
+    setToasts((t) => [...t, { id, message }]);
+    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 2000);
+  };
+  return (
+    <ToastContext.Provider value={{ toasts, add }}>
+      {children}
+      <div aria-live="polite" className="fixed bottom-2 right-2 space-y-2">
+        {toasts.map((t) => (
+          <div key={t.id} className="bg-black text-white px-3 py-2 rounded">
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToasts = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToasts must be used within ToastProvider');
+  return ctx;
+};

--- a/src/data/seedUser.ts
+++ b/src/data/seedUser.ts
@@ -1,0 +1,4 @@
+export const seedUser = {
+  email: 'demo@example.com',
+  password: 'demo1234',
+};

--- a/src/routes/settings/Account.test.tsx
+++ b/src/routes/settings/Account.test.tsx
@@ -1,0 +1,30 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Account from './Account';
+import { ToastProvider } from '../../components/settings/Toasts';
+import { useSettingsStore } from '../../stores/settings';
+
+function renderWithProviders() {
+  return render(
+    <ToastProvider>
+      <Account />
+    </ToastProvider>
+  );
+}
+
+describe('Account component', () => {
+  it('logs in user', async () => {
+    useSettingsStore.getState().update({ account: { session: 'disconnected' } });
+    renderWithProviders();
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Mot de passe'), {
+      target: { value: 'abcd' },
+    });
+    fireEvent.click(screen.getByText('Se connecter'));
+    await waitFor(() =>
+      expect(useSettingsStore.getState().account.session).toBe('connected')
+    );
+  });
+});

--- a/src/routes/settings/Account.tsx
+++ b/src/routes/settings/Account.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { login, logout } from '../../api/user';
+import { useAccount, useSettingsStore } from '../../stores/settings';
+import { useToasts } from '../../components/settings/Toasts';
+
+const schema = z.object({ email: z.string().email(), password: z.string().min(4) });
+type FormValues = z.infer<typeof schema>;
+
+export default function Account() {
+  const account = useAccount();
+  const update = useSettingsStore((s) => s.update);
+  const { add } = useToasts();
+  const { register, handleSubmit, formState } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    const user = await login(values);
+    update({ account: { session: 'connected', email: user.email } });
+    add('Connecté');
+  });
+
+  const handleLogout = async () => {
+    await logout();
+    update({ account: { session: 'disconnected' } });
+    add('Déconnecté');
+  };
+
+  return (
+    <div className="space-y-4">
+      <p>État de session: {account.session === 'connected' ? 'Connecté' : 'Déconnecté'}</p>
+      {account.session === 'connected' ? (
+        <div className="space-y-2">
+          <p>{account.email}</p>
+          <button onClick={handleLogout} className="px-3 py-2 border rounded">
+            Se déconnecter
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-2">
+          <input
+            {...register('email')}
+            placeholder="Email"
+            className="border p-2 rounded w-full"
+          />
+          {formState.errors.email && <span className="text-red-500 text-sm">Email invalide</span>}
+          <input
+            {...register('password')}
+            type="password"
+            placeholder="Mot de passe"
+            className="border p-2 rounded w-full"
+          />
+          <button type="submit" disabled={formState.isSubmitting} className="px-3 py-2 border rounded">
+            Se connecter
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/routes/settings/Alerts.tsx
+++ b/src/routes/settings/Alerts.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { alertsSchema, AlertsValues } from '../../validation/alerts';
+import { useAlerts, useSettingsStore } from '../../stores/settings';
+import { useToasts } from '../../components/settings/Toasts';
+import { Switch } from '../../components/settings/Switch';
+
+export default function Alerts() {
+  const alerts = useAlerts();
+  const update = useSettingsStore((s) => s.update);
+  const { add } = useToasts();
+  const { handleSubmit, watch, setValue } = useForm<AlertsValues>({
+    resolver: zodResolver(alertsSchema),
+    defaultValues: alerts,
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    update({ alerts: values });
+    add('Alertes enregistrées');
+  });
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <Switch
+        checked={watch('optimum')}
+        onChange={(v) => setValue('optimum', v)}
+        label="Optimum prévu"
+      />
+      <Switch
+        checked={watch('newZone')}
+        onChange={(v) => setValue('newZone', v)}
+        label="Nouvelle zone proche"
+      />
+      <button type="submit" className="px-3 py-2 border rounded">
+        Enregistrer
+      </button>
+    </form>
+  );
+}

--- a/src/routes/settings/Legal.tsx
+++ b/src/routes/settings/Legal.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Legal() {
+  return (
+    <div className="space-y-2">
+      <a href="/privacy" className="text-blue-600 underline">
+        Politique de confidentialité
+      </a>
+      <a href="/terms" className="text-blue-600 underline block">
+        Conditions d'utilisation
+      </a>
+      <button className="px-3 py-2 border rounded">Exporter mes données</button>
+      <button className="px-3 py-2 border rounded">Supprimer mes données</button>
+    </div>
+  );
+}

--- a/src/routes/settings/OfflineMaps.tsx
+++ b/src/routes/settings/OfflineMaps.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { enqueue } from '../../api/maps';
+import { MapAreaPicker } from '../../components/settings/MapAreaPicker';
+import { DownloadQueue } from '../../components/settings/DownloadQueue';
+import { useToasts } from '../../components/settings/Toasts';
+
+export default function OfflineMaps() {
+  const { add } = useToasts();
+  const [area, setArea] = useState({ lat: 45.764, lng: 4.8357, radius: 10 });
+  const handleDownload = async () => {
+    await enqueue({ id: Date.now().toString(), name: 'Zone', radiusKm: area.radius });
+    add('Téléchargement ajouté');
+  };
+  return (
+    <div className="space-y-4">
+      <MapAreaPicker onChange={(lat, lng, radius) => setArea({ lat, lng, radius })} />
+      <button onClick={handleDownload} className="px-3 py-2 border rounded">
+        Télécharger une zone
+      </button>
+      <DownloadQueue />
+    </div>
+  );
+}

--- a/src/routes/settings/Preferences.tsx
+++ b/src/routes/settings/Preferences.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { preferencesSchema, PreferencesValues } from '../../validation/preferences';
+import { usePrefs, useSettingsStore } from '../../stores/settings';
+import { Switch } from '../../components/settings/Switch';
+import { Select } from '../../components/settings/Select';
+import { useToasts } from '../../components/settings/Toasts';
+
+export default function Preferences() {
+  const prefs = usePrefs();
+  const update = useSettingsStore((s) => s.update);
+  const { add } = useToasts();
+  const { handleSubmit, watch, setValue } = useForm<PreferencesValues>({
+    resolver: zodResolver(preferencesSchema),
+    defaultValues: prefs,
+  });
+
+  const onSubmit = handleSubmit((values) => {
+    update({ prefs: values });
+    add('Préférences enregistrées');
+  });
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <Select
+        label="Unités"
+        value={watch('units')}
+        onChange={(v) => setValue('units', v as any)}
+        options={[
+          { value: 'metric', label: 'métriques' },
+          { value: 'imperial', label: 'impériales' },
+        ]}
+      />
+      <Switch
+        checked={watch('gps')}
+        onChange={(v) => setValue('gps', v)}
+        label="GPS"
+      />
+      <Select
+        label="Langue"
+        value={watch('lang')}
+        onChange={(v) => setValue('lang', v as any)}
+        options={[
+          { value: 'fr', label: 'français' },
+          { value: 'en', label: 'anglais' },
+        ]}
+      />
+      <Select
+        label="Thème"
+        value={watch('theme')}
+        onChange={(v) => setValue('theme', v as any)}
+        options={[
+          { value: 'system', label: 'Système' },
+          { value: 'light', label: 'Clair' },
+          { value: 'dark', label: 'Sombre' },
+        ]}
+      />
+      <button type="submit" className="px-3 py-2 border rounded">
+        Enregistrer
+      </button>
+    </form>
+  );
+}

--- a/src/routes/settings/Subscription.tsx
+++ b/src/routes/settings/Subscription.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { upgrade } from '../../api/subscription';
+import { useSubscription, useSettingsStore } from '../../stores/settings';
+import { useToasts } from '../../components/settings/Toasts';
+
+export default function Subscription() {
+  const sub = useSubscription();
+  const update = useSettingsStore((s) => s.update);
+  const { add } = useToasts();
+  const [loading, setLoading] = useState(false);
+
+  const handleUpgrade = async () => {
+    setLoading(true);
+    const res = await upgrade();
+    update({ subscription: res });
+    add('Passé en Premium');
+    setLoading(false);
+  };
+
+  return (
+    <div className="space-y-2">
+      <p>Statut: {sub.status === 'premium' ? 'Premium' : 'Gratuit'}</p>
+      {sub.renewalDate && <p>Renouvellement: {new Date(sub.renewalDate).toLocaleDateString()}</p>}
+      {sub.status === 'free' && (
+        <button
+          onClick={handleUpgrade}
+          disabled={loading}
+          className="px-3 py-2 border rounded"
+        >
+          Passer en Premium
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import Account from './Account';
+import Subscription from './Subscription';
+import OfflineMaps from './OfflineMaps';
+import Alerts from './Alerts';
+import Preferences from './Preferences';
+import Legal from './Legal';
+
+const sections = [
+  { id: 'account', label: 'Compte', component: <Account /> },
+  { id: 'subscription', label: 'Abonnement', component: <Subscription /> },
+  { id: 'maps', label: 'Cartes hors-ligne', component: <OfflineMaps /> },
+  { id: 'alerts', label: 'Alertes', component: <Alerts /> },
+  { id: 'prefs', label: 'Préférences', component: <Preferences /> },
+  { id: 'legal', label: 'Légal', component: <Legal /> },
+];
+
+export default function SettingsIndex() {
+  const [tab, setTab] = useState('account');
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Réglages</h1>
+      <div className="hidden md:flex gap-2 mb-4" role="tablist">
+        {sections.map((s) => (
+          <button
+            key={s.id}
+            role="tab"
+            aria-selected={tab === s.id}
+            onClick={() => setTab(s.id)}
+            className={`px-2 py-1 border-b-2 ${tab === s.id ? 'border-black' : 'border-transparent'}`}
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+      <div className="md:hidden" role="presentation">
+        {sections.map((s) => (
+          <details key={s.id} className="mb-2" open={tab === s.id} onClick={() => setTab(s.id)}>
+            <summary className="font-medium">{s.label}</summary>
+            <div className="p-2">{s.component}</div>
+          </details>
+        ))}
+      </div>
+      <div className="hidden md:block" role="tabpanel">
+        {sections.find((s) => s.id === tab)?.component}
+      </div>
+    </div>
+  );
+}

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { act } from '@testing-library/react';
+import { useSettingsStore } from './settings';
+
+describe('settings store', () => {
+  it('updates alerts', () => {
+    const { update, alerts } = useSettingsStore.getState();
+    expect(alerts.optimum).toBe(false);
+    act(() => update({ alerts: { optimum: true, newZone: false } }));
+    expect(useSettingsStore.getState().alerts.optimum).toBe(true);
+  });
+});

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type AccountState = {
+  session: 'connected' | 'disconnected';
+  email?: string;
+};
+
+export type SubscriptionState = {
+  status: 'free' | 'premium';
+  renewalDate?: string;
+  trialEnds?: string;
+  paymentError?: boolean;
+};
+
+export type AlertsState = {
+  optimum: boolean;
+  newZone: boolean;
+};
+
+export type PrefsState = {
+  units: 'metric' | 'imperial';
+  gps: boolean;
+  lang: 'fr' | 'en';
+  theme: 'system' | 'light' | 'dark';
+};
+
+export type SettingsState = {
+  account: AccountState;
+  subscription: SubscriptionState;
+  alerts: AlertsState;
+  prefs: PrefsState;
+  updatedAt: number;
+};
+
+export type SettingsActions = {
+  update: (partial: Partial<SettingsState>) => void;
+  reset: () => void;
+};
+
+const defaultState: SettingsState = {
+  account: { session: 'disconnected' },
+  subscription: { status: 'free' },
+  alerts: { optimum: false, newZone: false },
+  prefs: { units: 'metric', gps: false, lang: 'fr', theme: 'system' },
+  updatedAt: Date.now(),
+};
+
+export const useSettingsStore = create<SettingsState & SettingsActions>()(
+  persist(
+    (set) => ({
+      ...defaultState,
+      update: (partial) =>
+        set((state) => ({ ...state, ...partial, updatedAt: Date.now() })),
+      reset: () => set(defaultState),
+    }),
+    {
+      name: 'settings-store',
+      version: 1,
+    }
+  )
+);
+
+export const useAlerts = () => useSettingsStore((s) => s.alerts);
+export const usePrefs = () => useSettingsStore((s) => s.prefs);
+export const useAccount = () => useSettingsStore((s) => s.account);
+export const useSubscription = () => useSettingsStore((s) => s.subscription);

--- a/src/validation/alerts.ts
+++ b/src/validation/alerts.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const alertsSchema = z.object({
+  optimum: z.boolean(),
+  newZone: z.boolean(),
+});
+
+export type AlertsValues = z.infer<typeof alertsSchema>;

--- a/src/validation/preferences.ts
+++ b/src/validation/preferences.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const preferencesSchema = z.object({
+  units: z.enum(['metric', 'imperial']),
+  gps: z.boolean(),
+  lang: z.enum(['fr', 'en']),
+  theme: z.enum(['system', 'light', 'dark']),
+});
+
+export type PreferencesValues = z.infer<typeof preferencesSchema>;


### PR DESCRIPTION
## Summary
- refactor settings into modular route with tabs/accordions
- add zustand store with persistence and validation schemas
- provide basic account, subscription, maps, alerts, preferences and legal sections
- include tests and mocked APIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a5e327b508329a7b662d3dcd6c05e