### PR TITLE
Color zone graphs green and animate lines

### DIFF
--- a/src/components/ZoneDashboard.tsx
+++ b/src/components/ZoneDashboard.tsx
@@ -34,11 +34,27 @@ export default function ZoneDashboard({ zone, onGo, onAdd, onOpenShroom, onClose
           <div className="h-56">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-                <XAxis dataKey="day" tick={{ fontSize: 10 }} interval={3} />
-                <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} width={28} />
+                <XAxis
+                  dataKey="day"
+                  tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }}
+                  interval={3}
+                />
+                <YAxis
+                  domain={[0, 100]}
+                  tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }}
+                  width={28}
+                />
                 <Tooltip />
                 <ReferenceLine x={data[7].day} strokeDasharray="3 3" />
-                <Line type="monotone" dataKey="score" strokeWidth={2} dot={false} />
+                <Line
+                  type="monotone"
+                  dataKey="score"
+                  stroke="hsl(var(--fern-green))"
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive
+                  animationDuration={800}
+                />
               </LineChart>
             </ResponsiveContainer>
           </div>

--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -46,15 +46,38 @@ export default function ZoneScene({ zone, onAdd, onOpenShroom, onBack }: { zone:
         </CardHeader>
         <CardContent>
           <div className="h-56">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={data} margin={{ top: 10, right: 10, bottom: 0, left: 0 }}>
-                <XAxis dataKey="day" tick={{ fontSize: 10, fill: "#d4d4d4" }} interval={3} />
-                <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "#d4d4d4" }} width={28} />
-                <Tooltip contentStyle={{ background: "#171717", border: "1px solid #262626", borderRadius: 12, color: "#e5e5e5" }} />
-                <ReferenceLine x={data[7].day} stroke="#525252" strokeDasharray="3 3" />
-                <Line type="monotone" dataKey="score" stroke="#e5e5e5" strokeWidth={2} dot={false} />
-              </LineChart>
-            </ResponsiveContainer>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={data} margin={{ top: 10, right: 10, bottom: 0, left: 0 }}>
+                  <XAxis
+                    dataKey="day"
+                    tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }}
+                    interval={3}
+                  />
+                  <YAxis
+                    domain={[0, 100]}
+                    tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }}
+                    width={28}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: "#171717",
+                      border: "1px solid #262626",
+                      borderRadius: 12,
+                      color: "#e5e5e5",
+                    }}
+                  />
+                  <ReferenceLine x={data[7].day} stroke="#525252" strokeDasharray="3 3" />
+                  <Line
+                    type="monotone"
+                    dataKey="score"
+                    stroke="hsl(var(--fern-green))"
+                    strokeWidth={2}
+                    dot={false}
+                    isAnimationActive
+                    animationDuration={800}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
           </div>
           <div className={`mt-2 text-xs ${T_SUBTLE}`}>{t("Icônes météo (démo)")}</div>
 


### PR DESCRIPTION
## Summary
- style zone charts with forest and fern greens
- animate zone forecast line for a livelier graph

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a5f81251c8329890b3c1970992338