### PR TITLE
Refactor settings module to use design system

### DIFF
--- a/src/components/settings/ActionsBar.tsx
+++ b/src/components/settings/ActionsBar.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export function ActionsBar({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:justify-end">
+      {children}
+    </div>
+  );
+}
+
+export default ActionsBar;

--- a/src/components/settings/FieldRow.tsx
+++ b/src/components/settings/FieldRow.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface Props {
+  label: string;
+  help?: string;
+  error?: string;
+  children: React.ReactNode;
+}
+
+export function FieldRow({ label, help, error, children }: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm font-medium text-foreground">{label}</label>
+      {children}
+      {help && <p className="text-sm text-foreground/70">{help}</p>}
+      {error && (
+        <p className="text-sm text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default FieldRow;

--- a/src/components/settings/Section.tsx
+++ b/src/components/settings/Section.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+
+export function Section({ id, children }: { id?: string; children: React.ReactNode }) {
+  return (
+    <Card id={id} className="py-6 px-5 md:py-8 md:px-8 space-y-5">
+      {children}
+    </Card>
+  );
+}
+
+export default Section;

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+type Item = { id: string; label: string; content: React.ReactNode };
+
+export function Accordion({ items, value, onChange }: { items: Item[]; value: string; onChange: (id: string) => void }) {
+  return (
+    <div className="space-y-2">
+      {items.map((it) => (
+        <details
+          key={it.id}
+          open={value === it.id}
+          onToggle={(e) => {
+            if (e.currentTarget.open) onChange(it.id);
+          }}
+          className="border border-border rounded-md"
+        >
+          <summary className="cursor-pointer px-4 py-2 text-sm font-medium text-foreground">
+            {it.label}
+          </summary>
+          <div className="px-4 py-2">
+            {it.content}
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+export default Accordion;

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 
-export function Input({ className = "", ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
-  const base =
-    "flex h-10 w-full rounded-md border border-border bg-paper px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50 disabled:pointer-events-none";
-  return <input className={`${base} ${className}`} {...props} />;
-}
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className = "", ...props }, ref) => {
+    const base =
+      "flex h-10 w-full rounded-md border border-border bg-paper px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50 disabled:pointer-events-none";
+    return <input ref={ref} className={`${base} ${className}`} {...props} />;
+  }
+);
+
+Input.displayName = "Input";
 

--- a/src/routes/settings/Account.tsx
+++ b/src/routes/settings/Account.tsx
@@ -5,6 +5,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { login, logout } from '../../api/user';
 import { useAccount, useSettingsStore } from '../../stores/settings';
 import { useToasts } from '../../components/settings/Toasts';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import FieldRow from '@/components/settings/FieldRow';
+import ActionsBar from '@/components/settings/ActionsBar';
 
 const schema = z.object({ email: z.string().email(), password: z.string().min(4) });
 type FormValues = z.infer<typeof schema>;
@@ -13,7 +17,11 @@ export default function Account() {
   const account = useAccount();
   const update = useSettingsStore((s) => s.update);
   const { add } = useToasts();
-  const { register, handleSubmit, formState } = useForm<FormValues>({
+  const {
+    register,
+    handleSubmit,
+    formState,
+  } = useForm<FormValues>({
     resolver: zodResolver(schema),
   });
 
@@ -30,32 +38,46 @@ export default function Account() {
   };
 
   return (
-    <div className="space-y-4">
-      <p>État de session: {account.session === 'connected' ? 'Connecté' : 'Déconnecté'}</p>
+    <div className="space-y-6">
+      <p className="text-sm text-foreground">État de session: {account.session === 'connected' ? 'Connecté' : 'Déconnecté'}</p>
       {account.session === 'connected' ? (
-        <div className="space-y-2">
+        <div className="space-y-4">
           <p>{account.email}</p>
-          <button onClick={handleLogout} className="px-3 py-2 border rounded">
-            Se déconnecter
-          </button>
+          <ActionsBar>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleLogout}
+              className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm"
+            >
+              Se déconnecter
+            </Button>
+          </ActionsBar>
         </div>
       ) : (
-        <form onSubmit={onSubmit} className="space-y-2">
-          <input
-            {...register('email')}
-            placeholder="Email"
-            className="border p-2 rounded w-full"
-          />
-          {formState.errors.email && <span className="text-red-500 text-sm">Email invalide</span>}
-          <input
-            {...register('password')}
-            type="password"
-            placeholder="Mot de passe"
-            className="border p-2 rounded w-full"
-          />
-          <button type="submit" disabled={formState.isSubmitting} className="px-3 py-2 border rounded">
-            Se connecter
-          </button>
+        <form onSubmit={onSubmit} className="space-y-6">
+          <FieldRow
+            label="Email"
+            error={formState.errors.email && 'Email invalide'}
+          >
+            <Input {...register('email')} placeholder="Email" />
+          </FieldRow>
+          <FieldRow label="Mot de passe">
+            <Input
+              {...register('password')}
+              type="password"
+              placeholder="Mot de passe"
+            />
+          </FieldRow>
+          <ActionsBar>
+            <Button
+              type="submit"
+              disabled={formState.isSubmitting}
+              className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm"
+            >
+              Se connecter
+            </Button>
+          </ActionsBar>
         </form>
       )}
     </div>

--- a/src/routes/settings/Alerts.tsx
+++ b/src/routes/settings/Alerts.tsx
@@ -4,7 +4,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { alertsSchema, AlertsValues } from '../../validation/alerts';
 import { useAlerts, useSettingsStore } from '../../stores/settings';
 import { useToasts } from '../../components/settings/Toasts';
-import { Switch } from '../../components/settings/Switch';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import FieldRow from '@/components/settings/FieldRow';
+import ActionsBar from '@/components/settings/ActionsBar';
 
 export default function Alerts() {
   const alerts = useAlerts();
@@ -21,20 +24,24 @@ export default function Alerts() {
   });
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <Switch
-        checked={watch('optimum')}
-        onChange={(v) => setValue('optimum', v)}
-        label="Optimum prévu"
-      />
-      <Switch
-        checked={watch('newZone')}
-        onChange={(v) => setValue('newZone', v)}
-        label="Nouvelle zone proche"
-      />
-      <button type="submit" className="px-3 py-2 border rounded">
-        Enregistrer
-      </button>
+    <form onSubmit={onSubmit} className="space-y-6">
+      <FieldRow label="Optimum prévu">
+        <Switch
+          checked={watch('optimum')}
+          onCheckedChange={(v) => setValue('optimum', v)}
+        />
+      </FieldRow>
+      <FieldRow label="Nouvelle zone proche">
+        <Switch
+          checked={watch('newZone')}
+          onCheckedChange={(v) => setValue('newZone', v)}
+        />
+      </FieldRow>
+      <ActionsBar>
+        <Button type="submit" className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm">
+          Enregistrer
+        </Button>
+      </ActionsBar>
     </form>
   );
 }

--- a/src/routes/settings/Legal.tsx
+++ b/src/routes/settings/Legal.tsx
@@ -1,16 +1,24 @@
 import React from 'react';
+import { Button } from '@/components/ui/button';
+import ActionsBar from '@/components/settings/ActionsBar';
 
 export default function Legal() {
   return (
-    <div className="space-y-2">
-      <a href="/privacy" className="text-blue-600 underline">
+    <div className="space-y-6">
+      <a href="/privacy" className="text-sm text-foreground underline">
         Politique de confidentialité
       </a>
-      <a href="/terms" className="text-blue-600 underline block">
+      <a href="/terms" className="text-sm text-foreground underline">
         Conditions d'utilisation
       </a>
-      <button className="px-3 py-2 border rounded">Exporter mes données</button>
-      <button className="px-3 py-2 border rounded">Supprimer mes données</button>
+      <ActionsBar>
+        <Button variant="secondary" className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm">
+          Exporter mes données
+        </Button>
+        <Button variant="destructive" className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm">
+          Supprimer mes données
+        </Button>
+      </ActionsBar>
     </div>
   );
 }

--- a/src/routes/settings/OfflineMaps.tsx
+++ b/src/routes/settings/OfflineMaps.tsx
@@ -3,6 +3,8 @@ import { enqueue } from '../../api/maps';
 import { MapAreaPicker } from '../../components/settings/MapAreaPicker';
 import { DownloadQueue } from '../../components/settings/DownloadQueue';
 import { useToasts } from '../../components/settings/Toasts';
+import { Button } from '@/components/ui/button';
+import ActionsBar from '@/components/settings/ActionsBar';
 
 export default function OfflineMaps() {
   const { add } = useToasts();
@@ -12,11 +14,16 @@ export default function OfflineMaps() {
     add('Téléchargement ajouté');
   };
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <MapAreaPicker onChange={(lat, lng, radius) => setArea({ lat, lng, radius })} />
-      <button onClick={handleDownload} className="px-3 py-2 border rounded">
-        Télécharger une zone
-      </button>
+      <ActionsBar>
+        <Button
+          onClick={handleDownload}
+          className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm"
+        >
+          Télécharger une zone
+        </Button>
+      </ActionsBar>
       <DownloadQueue />
     </div>
   );

--- a/src/routes/settings/Preferences.tsx
+++ b/src/routes/settings/Preferences.tsx
@@ -3,9 +3,12 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { preferencesSchema, PreferencesValues } from '../../validation/preferences';
 import { usePrefs, useSettingsStore } from '../../stores/settings';
-import { Switch } from '../../components/settings/Switch';
-import { Select } from '../../components/settings/Select';
 import { useToasts } from '../../components/settings/Toasts';
+import { Switch } from '@/components/ui/switch';
+import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import FieldRow from '@/components/settings/FieldRow';
+import ActionsBar from '@/components/settings/ActionsBar';
 
 export default function Preferences() {
   const prefs = usePrefs();
@@ -22,43 +25,46 @@ export default function Preferences() {
   });
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <Select
-        label="Unités"
-        value={watch('units')}
-        onChange={(v) => setValue('units', v as any)}
-        options={[
-          { value: 'metric', label: 'métriques' },
-          { value: 'imperial', label: 'impériales' },
-        ]}
-      />
-      <Switch
-        checked={watch('gps')}
-        onChange={(v) => setValue('gps', v)}
-        label="GPS"
-      />
-      <Select
-        label="Langue"
-        value={watch('lang')}
-        onChange={(v) => setValue('lang', v as any)}
-        options={[
-          { value: 'fr', label: 'français' },
-          { value: 'en', label: 'anglais' },
-        ]}
-      />
-      <Select
-        label="Thème"
-        value={watch('theme')}
-        onChange={(v) => setValue('theme', v as any)}
-        options={[
-          { value: 'system', label: 'Système' },
-          { value: 'light', label: 'Clair' },
-          { value: 'dark', label: 'Sombre' },
-        ]}
-      />
-      <button type="submit" className="px-3 py-2 border rounded">
-        Enregistrer
-      </button>
+    <form onSubmit={onSubmit} className="space-y-6">
+      <FieldRow label="Unités">
+        <Select
+          value={watch('units')}
+          onChange={(e) => setValue('units', e.target.value as any)}
+        >
+          <option value="metric">métriques</option>
+          <option value="imperial">impériales</option>
+        </Select>
+      </FieldRow>
+      <FieldRow label="GPS">
+        <Switch
+          checked={watch('gps')}
+          onCheckedChange={(v) => setValue('gps', v)}
+        />
+      </FieldRow>
+      <FieldRow label="Langue">
+        <Select
+          value={watch('lang')}
+          onChange={(e) => setValue('lang', e.target.value as any)}
+        >
+          <option value="fr">français</option>
+          <option value="en">anglais</option>
+        </Select>
+      </FieldRow>
+      <FieldRow label="Thème">
+        <Select
+          value={watch('theme')}
+          onChange={(e) => setValue('theme', e.target.value as any)}
+        >
+          <option value="system">Système</option>
+          <option value="light">Clair</option>
+          <option value="dark">Sombre</option>
+        </Select>
+      </FieldRow>
+      <ActionsBar>
+        <Button type="submit" className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm">
+          Enregistrer
+        </Button>
+      </ActionsBar>
     </form>
   );
 }

--- a/src/routes/settings/Subscription.tsx
+++ b/src/routes/settings/Subscription.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { upgrade } from '../../api/subscription';
 import { useSubscription, useSettingsStore } from '../../stores/settings';
 import { useToasts } from '../../components/settings/Toasts';
+import { Button } from '@/components/ui/button';
+import ActionsBar from '@/components/settings/ActionsBar';
 
 export default function Subscription() {
   const sub = useSubscription();
@@ -18,17 +20,21 @@ export default function Subscription() {
   };
 
   return (
-    <div className="space-y-2">
-      <p>Statut: {sub.status === 'premium' ? 'Premium' : 'Gratuit'}</p>
-      {sub.renewalDate && <p>Renouvellement: {new Date(sub.renewalDate).toLocaleDateString()}</p>}
+    <div className="space-y-6">
+      <p className="text-sm text-foreground">Statut: {sub.status === 'premium' ? 'Premium' : 'Gratuit'}</p>
+      {sub.renewalDate && (
+        <p className="text-sm text-foreground">Renouvellement: {new Date(sub.renewalDate).toLocaleDateString()}</p>
+      )}
       {sub.status === 'free' && (
-        <button
-          onClick={handleUpgrade}
-          disabled={loading}
-          className="px-3 py-2 border rounded"
-        >
-          Passer en Premium
-        </button>
+        <ActionsBar>
+          <Button
+            onClick={handleUpgrade}
+            disabled={loading}
+            className="w-full md:w-auto h-10 px-4 rounded-lg shadow-sm"
+          >
+            Passer en Premium
+          </Button>
+        </ActionsBar>
       )}
     </div>
   );

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1,48 +1,65 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Account from './Account';
 import Subscription from './Subscription';
 import OfflineMaps from './OfflineMaps';
 import Alerts from './Alerts';
 import Preferences from './Preferences';
 import Legal from './Legal';
+import { Tabs } from '@/components/ui/tabs';
+import { Accordion } from '@/components/ui/accordion';
+import Section from '@/components/settings/Section';
+import '../../styles/settings.css';
 
 const sections = [
-  { id: 'account', label: 'Compte', component: <Account /> },
-  { id: 'subscription', label: 'Abonnement', component: <Subscription /> },
-  { id: 'maps', label: 'Cartes hors-ligne', component: <OfflineMaps /> },
-  { id: 'alerts', label: 'Alertes', component: <Alerts /> },
-  { id: 'prefs', label: 'Préférences', component: <Preferences /> },
-  { id: 'legal', label: 'Légal', component: <Legal /> },
+  { id: 'account', label: 'Compte', element: <Account /> },
+  { id: 'abonnement', label: 'Abonnement', element: <Subscription /> },
+  { id: 'cartes', label: 'Cartes hors-ligne', element: <OfflineMaps /> },
+  { id: 'alertes', label: 'Alertes', element: <Alerts /> },
+  { id: 'preferences', label: 'Préférences', element: <Preferences /> },
+  { id: 'legal', label: 'Légal', element: <Legal /> },
 ];
 
 export default function SettingsIndex() {
-  const [tab, setTab] = useState('account');
+  const [active, setActive] = useState(() =>
+    window.location.hash.replace('#', '') || 'account'
+  );
+
+  useEffect(() => {
+    if (active) window.location.hash = active;
+  }, [active]);
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Réglages</h1>
-      <div className="hidden md:flex gap-2 mb-4" role="tablist">
-        {sections.map((s) => (
-          <button
-            key={s.id}
-            role="tab"
-            aria-selected={tab === s.id}
-            onClick={() => setTab(s.id)}
-            className={`px-2 py-1 border-b-2 ${tab === s.id ? 'border-black' : 'border-transparent'}`}
-          >
-            {s.label}
-          </button>
-        ))}
+    <div className="container max-w-3xl mx-auto px-4 py-6 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-foreground">Réglages</h1>
+        <p className="text-sm text-foreground/70">Configurer l'application</p>
+      </header>
+
+      <div className="md:hidden">
+        <Accordion
+          items={sections.map((s) => ({
+            id: s.id,
+            label: s.label,
+            content: <Section id={s.id}>{s.element}</Section>,
+          }))}
+          value={active}
+          onChange={setActive}
+        />
       </div>
-      <div className="md:hidden" role="presentation">
-        {sections.map((s) => (
-          <details key={s.id} className="mb-2" open={tab === s.id} onClick={() => setTab(s.id)}>
-            <summary className="font-medium">{s.label}</summary>
-            <div className="p-2">{s.component}</div>
-          </details>
-        ))}
-      </div>
-      <div className="hidden md:block" role="tabpanel">
-        {sections.find((s) => s.id === tab)?.component}
+
+      <div className="hidden md:block">
+        <Tabs
+          tabs={sections.map((s) => ({ id: s.id, label: s.label }))}
+          active={active}
+          onChange={setActive}
+        />
+        <div className="mt-6">
+          {sections.map((s) => (
+            <div key={s.id} className={s.id === active ? 'block' : 'hidden'}>
+              <Section id={s.id}>{s.element}</Section>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,0 +1,1 @@
+/* Settings module overrides using design tokens only */


### PR DESCRIPTION
## Summary
- Refactor Settings index to use Tabs on desktop and Accordion on mobile
- Add Section, FieldRow, and ActionsBar components for consistent layout
- Apply design-system Buttons, Inputs, Selects, Switches across Settings pages
- Fix Input component to forward refs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a6188442483298d000d6f4cce0e3b