### PR TITLE
Use Carto tiles for static map previews

### DIFF
--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -78,7 +78,10 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
           spots.map(s => {
             const [lat, lng] = s.location ? s.location.split(",").map(v => parseFloat(v.trim())) : [NaN, NaN];
             const hasLoc = !Number.isNaN(lat) && !Number.isNaN(lng);
-            const mapUrl = hasLoc ? getStaticMapUrl(lat, lng) : s.cover || s.photos?.[0];
+            const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+            const mapUrl = hasLoc
+              ? getStaticMapUrl(lat, lng, 400 * dpr, 160 * dpr)
+              : s.cover || s.photos?.[0];
             return (
               <Card
                 key={s.id}

--- a/src/services/openstreetmap.test.ts
+++ b/src/services/openstreetmap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 vi.mock('maplibre-gl', () => ({}));
-import { reverseGeocode } from './openstreetmap';
+import { reverseGeocode, getStaticMapUrl } from './openstreetmap';
 
 describe('reverseGeocode', () => {
   it('returns nearest place name', async () => {
@@ -20,5 +20,13 @@ describe('reverseGeocode', () => {
     const name = await reverseGeocode(0, 0);
     expect(name).toBeNull();
     vi.unstubAllGlobals();
+  });
+});
+
+describe('getStaticMapUrl', () => {
+  it('uses Carto tiles with retina suffix when width is large', () => {
+    const url = getStaticMapUrl(48.8566, 2.3522, 400, 200, 13);
+    expect(url).toMatch(/basemaps\.cartocdn\.com/);
+    expect(url).toMatch(/@2x\.png$/);
   });
 });

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -6,17 +6,21 @@ export async function loadMap() {
 }
 
 export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 160, zoom = 13) {
-  // StaticMap from staticmap.openstreetmap.de sometimes returns 403 depending
-  // on the execution environment. To avoid relying on that service, build a
-  // URL pointing directly to the OpenStreetMap tile server. We compute the
-  // tile x/y for the given lat/lng and zoom. The returned tile is 256×256px
-  // and will be scaled by the caller via CSS.
+  // Build a static tile URL using the same provider as the interactive map
+  // (Carto "positron" style). We compute the tile x/y for the given lat/lng
+  // and zoom and request a high‑resolution variant depending on the requested
+  // width/height. Carto tiles support a "@2x" suffix for retina displays. We
+  // choose the scale so that the returned image is at least as big as the
+  // requested size, capped at 2× to match provider capabilities.
   const xtile = Math.floor(((lng + 180) / 360) * Math.pow(2, zoom));
   const ytile = Math.floor(
     ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
       Math.pow(2, zoom)
   );
-  return `https://tile.openstreetmap.org/${zoom}/${xtile}/${ytile}.png`;
+  const scale = Math.min(2, Math.ceil(Math.max(width, height) / 256));
+  const suffix = scale > 1 ? `@${scale}x` : "";
+  const sub = ["a", "b", "c", "d"][Math.floor(Math.random() * 4)];
+  return `https://${sub}.basemaps.cartocdn.com/light_all/${zoom}/${xtile}/${ytile}${suffix}.png`;
 }
 
 export async function geocode(query: string) {


### PR DESCRIPTION
## Summary
- switch static map helper to Carto Positron tiles with high-res support
- request high-resolution thumbnails in SpotsScene using device pixel ratio
- add unit test covering Carto static map URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0def11cc832980e6bd5a225ab6b7