### PR TITLE
Add safe JSON parsing in AuthContext

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -14,16 +14,28 @@ interface AuthContextValue {
   upgrade: () => void;
 }
 
+function safeParse<T>(data: string, fallback: T): T {
+  try {
+    return JSON.parse(data) as T;
+  } catch (e) {
+    console.warn("Failed to parse JSON:", e);
+    return fallback;
+  }
+}
+
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(() => {
     const stored = localStorage.getItem("user");
-    return stored ? JSON.parse(stored) : null;
+    return stored ? safeParse<User | null>(stored, null) : null;
   });
 
   const login = (username: string, password: string) => {
-    const users = JSON.parse(localStorage.getItem("users") || "{}") as Record<string, { password: string; premium: boolean }>;
+    const users = safeParse<Record<string, { password: string; premium: boolean }>>(
+      localStorage.getItem("users") || "{}",
+      {}
+    );
     const record = users[username];
     if (record && record.password === password) {
       const u: User = { username, premium: !!record.premium };
@@ -35,7 +47,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const signup = (username: string, password: string) => {
-    const users = JSON.parse(localStorage.getItem("users") || "{}") as Record<string, { password: string; premium: boolean }>;
+    const users = safeParse<Record<string, { password: string; premium: boolean }>>(
+      localStorage.getItem("users") || "{}",
+      {}
+    );
     if (users[username]) return false;
     users[username] = { password, premium: false };
     localStorage.setItem("users", JSON.stringify(users));
@@ -46,10 +61,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const loginWithProvider = (provider: "google" | "apple") => {
-    const users = JSON.parse(localStorage.getItem("users") || "{}") as Record<
-      string,
-      { password: string; premium: boolean }
-    >;
+    const users = safeParse<Record<string, { password: string; premium: boolean }>>(
+      localStorage.getItem("users") || "{}",
+      {}
+    );
     if (!users[provider]) {
       users[provider] = { password: "", premium: false };
       localStorage.setItem("users", JSON.stringify(users));
@@ -69,7 +84,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const u = { ...user, premium: true };
     setUser(u);
     localStorage.setItem("user", JSON.stringify(u));
-    const users = JSON.parse(localStorage.getItem("users") || "{}") as Record<string, { password: string; premium: boolean }>;
+    const users = safeParse<Record<string, { password: string; premium: boolean }>>(
+      localStorage.getItem("users") || "{}",
+      {}
+    );
     if (users[user.username]) {
       users[user.username].premium = true;
       localStorage.setItem("users", JSON.stringify(users));


### PR DESCRIPTION
## Summary
- add generic `safeParse` helper around `JSON.parse` with fallback and warning
- use `safeParse` for all JSON parsing in `AuthContext` methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b15bfc1608329b02ec59844a927da