### PR TITLE
feat: allow running without Supabase

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,16 +1,19 @@
-import { createClient, Session } from '@supabase/supabase-js';
+import { createClient, type Session, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const sb = createClient(supabaseUrl, supabaseAnon);
+export const sb: SupabaseClient | null =
+  supabaseUrl && supabaseAnon ? createClient(supabaseUrl, supabaseAnon) : null;
 
 export async function getSession(): Promise<Session | null> {
+  if (!sb) return null;
   const { data } = await sb.auth.getSession();
   return data.session;
 }
 
 export async function signInGoogle(): Promise<void> {
+  if (!sb) return;
   const origin = window.location.origin;
   const { error } = await sb.auth.signInWithOAuth({
     provider: 'google',
@@ -20,6 +23,7 @@ export async function signInGoogle(): Promise<void> {
 }
 
 export async function signOut(): Promise<void> {
+  if (!sb) return;
   const { error } = await sb.auth.signOut();
   if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- avoid initializing Supabase when env variables are missing
- skip auth actions if Supabase is not configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b181459d48329908b9b20f93489d6