### PR TITLE
feat: make mushroom cards responsive grid links

### DIFF
--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -17,47 +17,53 @@ export default function MushroomCard({ mushroom, compact = false, onView, onAdd,
     if (e.key === "Enter") onDetails();
   };
   return (
-    <Card
-      className={compact ? "flex items-center gap-4" : "cursor-pointer"}
-      tabIndex={0}
-      onClick={onDetails}
+    <a
+      role="link"
+      href="#"
+      onClick={(e) => {
+        e.preventDefault();
+        onDetails();
+      }}
       onKeyDown={handleKey}
+      className="block h-full no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
     >
-      {compact ? (
-        <img
-          src={mushroom.photo}
-          alt=""
-          className="h-24 w-32 object-cover rounded-l-lg"
-          loading="lazy"
-        />
-      ) : (
-        <img
-          src={mushroom.photo}
-          alt=""
-          className="aspect-[4/3] w-full object-cover rounded-t-lg"
-          loading="lazy"
-        />
-      )}
-      <CardContent className={compact ? "p-4 flex-1" : "p-4 space-y-2"}>
-        <div className="flex items-center gap-2">
-          <CardTitle className="text-foreground text-lg font-semibold">{mushroom.name}</CardTitle>
-          {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
-        </div>
-        <p className="text-sm text-foreground/70 italic">{mushroom.latin}</p>
-        <div className="mt-2 flex flex-wrap gap-2">
-          <Button onClick={(e) => { e.stopPropagation(); onView(); }} className="text-sm py-1 px-2">
-            Voir sur la carte
-          </Button>
-          <Button
-            onClick={(e) => { e.stopPropagation(); onAdd(); }}
-            variant="secondary"
-            className="text-sm py-1 px-2"
-          >
-            Ajouter à mes coins
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+      <Card className={compact ? "flex items-center gap-4 h-full" : "cursor-pointer h-full"}>
+        {compact ? (
+          <img
+            src={mushroom.photo}
+            alt=""
+            className="h-24 w-32 object-cover rounded-l-lg"
+            loading="lazy"
+          />
+        ) : (
+          <img
+            src={mushroom.photo}
+            alt=""
+            className="aspect-[4/3] w-full object-cover rounded-t-lg"
+            loading="lazy"
+          />
+        )}
+        <CardContent className={compact ? "p-4 flex-1" : "p-4 space-y-2"}>
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-foreground text-lg font-semibold">{mushroom.name}</CardTitle>
+            {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
+          </div>
+          <p className="text-sm text-foreground/70 italic">{mushroom.latin}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <Button onClick={(e) => { e.stopPropagation(); onView(); }} className="text-sm py-1 px-2">
+              Voir sur la carte
+            </Button>
+            <Button
+              onClick={(e) => { e.stopPropagation(); onAdd(); }}
+              variant="secondary"
+              className="text-sm py-1 px-2"
+            >
+              Ajouter à mes coins
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </a>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -89,5 +89,5 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
 
 @layer utilities {
   .container { @apply max-w-screen-xl mx-auto px-4 md:px-6; }
-  .grid-responsive { @apply grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3; }
-}
+    .grid-responsive { @apply grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4; }
+  }

--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -88,6 +88,12 @@ describe("MushroomsIndex", () => {
     expect(select).toHaveFocus();
   });
 
+  it("renders cards as links", async () => {
+    render(<MushroomsIndex />);
+    await waitFor(() => screen.getByRole("link", { name: /Cèpe/ }));
+    expect(screen.getByRole("link", { name: /Cèpe/ })).toBeInTheDocument();
+  });
+
   it("shows loading and empty states", async () => {
     const { container } = render(<MushroomsIndex />);
     expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- make mushroom cards fully clickable links
- update responsive grid to 4/3/2/1 columns
- test card links render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c3615838c83299b3aadb82de78f6a