### PR TITLE
Fix Latin name visibility on mushroom pages

### DIFF
--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -43,7 +43,7 @@ export default function MushroomCard({ mushroom, compact = false, onView, onAdd,
           <CardTitle className="text-foreground text-lg font-semibold">{mushroom.name}</CardTitle>
           {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
         </div>
-        <p className="text-sm text-foreground/70 italic">{mushroom.latin}</p>
+        <p className="text-sm text-muted-foreground italic">{mushroom.latin}</p>
         <div className="mt-2 flex flex-wrap gap-2">
           <Button onClick={(e) => { e.stopPropagation(); onView(); }} className="text-sm py-1 px-2">
             Voir sur la carte

--- a/src/components/mushrooms/MushroomDetails.tsx
+++ b/src/components/mushrooms/MushroomDetails.tsx
@@ -21,7 +21,7 @@ export default function MushroomDetails({ mushroom, open, onClose }: Props) {
             <h2 className="text-xl font-semibold text-foreground">{mushroom.name}</h2>
             {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
           </div>
-          <p className="text-sm text-foreground/70 italic">{mushroom.latin}</p>
+          <p className="text-sm text-muted-foreground italic">{mushroom.latin}</p>
           <p className="text-sm text-foreground/80">{mushroom.description}</p>
           <div className="flex gap-2">
             <Button onClick={onClose}>Voir sur la carte</Button>

--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -27,7 +27,7 @@ export default function MushroomScene({ item, onSeeZones, onBack }: { item: Mush
         <div className="p-4 space-y-4">
           <div className="flex flex-wrap items-center gap-2">
             <h2 className={`text-xl font-semibold ${T_PRIMARY}`}>{item.name}</h2>
-            <Badge variant="secondary">{item.latin}</Badge>
+            <Badge>{item.latin}</Badge>
             {item.edible ? (
               <Badge className="bg-emerald-700">🍴 {t("comestible")}</Badge>
             ) : (


### PR DESCRIPTION
## Summary
- ensure Latin names use muted foreground color on cards and details
- use default badge style for Latin name in mushroom scene

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c36dc68588329bfb5450a19de7a22