### PR TITLE
Improve readability of Latin mushroom names

### DIFF
--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -48,7 +48,7 @@ export default function MushroomCard({ mushroom, compact = false, onView, onAdd,
             <CardTitle className="text-foreground text-lg font-semibold">{mushroom.name}</CardTitle>
             {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
           </div>
-          <p className="text-sm text-foreground/70 italic">{mushroom.latin}</p>
+          <p className="text-sm text-moss italic">{mushroom.latin}</p>
           <div className="mt-2 flex flex-wrap gap-2">
             <Button onClick={(e) => { e.stopPropagation(); onView(); }} className="text-sm py-1 px-2">
               Voir sur la carte

--- a/src/components/mushrooms/MushroomDetails.tsx
+++ b/src/components/mushrooms/MushroomDetails.tsx
@@ -21,7 +21,7 @@ export default function MushroomDetails({ mushroom, open, onClose }: Props) {
             <h2 className="text-xl font-semibold text-foreground">{mushroom.name}</h2>
             {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
           </div>
-          <p className="text-sm text-foreground/70 italic">{mushroom.latin}</p>
+          <p className="text-sm text-moss italic">{mushroom.latin}</p>
           <p className="text-sm text-foreground/80">{mushroom.description}</p>
           <div className="flex gap-2">
             <Button onClick={onClose}>Voir sur la carte</Button>


### PR DESCRIPTION
## Summary
- use moss green for Latin names in mushroom card and details to avoid white text on white background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c381c8b54832992106a3c7761e38f