### PR TITLE
Place map toasts in bottom-left

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -205,7 +205,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
           </div>
         </div>
         {toasts.length > 0 && (
-          <div className="absolute left-3 top-16 flex flex-col gap-2">
+          <div className="absolute left-3 bottom-3 flex flex-col gap-2">
             {toasts.map(toast => (
               <button
                 key={toast.id}


### PR DESCRIPTION
## Summary
- move toast notifications to bottom-left corner of the map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c3b8a4ae883299a4fc9263cdf18c4