### PR TITLE
Show spot history in dedicated page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import LandingScene from "./scenes/LandingScene";
 import MapScene from "./scenes/MapScene";
 import ZoneScene from "./scenes/ZoneScene";
 import SpotsScene from "./scenes/SpotsScene";
+import SpotDetailsScene from "./scenes/SpotDetailsScene";
 import PickerScene from "./scenes/PickerScene";
 import MushroomScene from "./scenes/MushroomScene";
 import SettingsIndex from "./routes/settings";
@@ -42,6 +43,7 @@ function AppContent() {
   const [search, setSearch] = useState("");
   const [selectedZone, setSelectedZone] = useState<Zone | null>(null);
   const [selectedMushroom, setSelectedMushroom] = useState<Mushroom | null>(null);
+  const [selectedSpot, setSelectedSpot] = useState<Spot | null>(null);
   const [downloading, setDownloading] = useState(false);
   const [dlProgress, setDlProgress] = useState(0);
   const [includeRelief, setIncludeRelief] = useState(true);
@@ -184,7 +186,22 @@ function AppContent() {
                 />
               }
             />
-            <Route path={Scene.Spots} element={<SpotsScene onBack={goBack} />} />
+            <Route
+              path={Scene.Spots}
+              element={
+                <SpotsScene
+                  onBack={goBack}
+                  onOpenSpot={(s) => {
+                    setSelectedSpot(s);
+                    goTo(Scene.Spot);
+                  }}
+                />
+              }
+            />
+            <Route
+              path={Scene.Spot}
+              element={<SpotDetailsScene spot={selectedSpot} onBack={goBack} />}
+            />
             <Route
               path={Scene.Picker}
               element={

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -3,6 +3,7 @@ export enum Scene {
   Map = '/map',
   Zone = '/zone',
   Spots = '/spots',
+  Spot = '/spot',
   Picker = '/picker',
   Mushroom = '/mushroom',
   Settings = '/settings',

--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -6,7 +6,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { CreateSpotModal } from "../components/CreateSpotModal";
-import { SpotDetailsModal } from "../components/SpotDetailsModal";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 import { useAppContext } from "../context/AppContext";
 import { useT } from "../i18n";
@@ -15,11 +14,10 @@ import Logo from "@/assets/logo.png";
 import { MUSHROOMS } from "../data/mushrooms";
 import type { Spot } from "../types";
 
-export default function SpotsScene({ onBack }: { onBack: () => void }) {
+export default function SpotsScene({ onBack, onOpenSpot }: { onBack: () => void; onOpenSpot: (s: Spot) => void }) {
   const { state, dispatch } = useAppContext();
   const spots = state.mySpots;
   const [createOpen, setCreateOpen] = useState(false);
-  const [details, setDetails] = useState<Spot | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const { t } = useT();
@@ -86,7 +84,7 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
             return (
               <Card
                 key={s.id}
-                onClick={() => setDetails(s)}
+                onClick={() => onOpenSpot(s)}
                 className="cursor-pointer bg-secondary dark:bg-secondary border border-secondary dark:border-secondary rounded-2xl overflow-hidden relative"
               >
                 {hasLoc ? (
@@ -147,10 +145,6 @@ export default function SpotsScene({ onBack }: { onBack: () => void }) {
             setCreateOpen(false);
           }}
         />
-      )}
-
-      {details && (
-        <SpotDetailsModal spot={details} onClose={() => setDetails(null)} />
       )}
 
       <ConfirmDeleteModal


### PR DESCRIPTION
## Summary
- Add `Scene.Spot` route and navigation to show spot history as a full page
- Create `SpotDetailsScene` page and remove old modal
- Update spots list to navigate to details page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3bccf38883299c0f1223f5325479