### PR TITLE
Refactor mushrooms page into responsive card grid

### DIFF
--- a/src/components/__tests__/StatsStack.test.tsx
+++ b/src/components/__tests__/StatsStack.test.tsx
@@ -11,6 +11,15 @@ beforeAll(() => {
   }
   // @ts-ignore
   global.ResizeObserver = ResizeObserver;
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 300,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 300,
+  });
 });
 
 describe("StatsStack", () => {

--- a/src/components/mushrooms/MushroomCard.skeleton.tsx
+++ b/src/components/mushrooms/MushroomCard.skeleton.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Skeleton from "@/components/ui/skeleton";
+
+export default function MushroomCardSkeleton() {
+  return (
+    <div className="h-full flex flex-col rounded-lg border border-border shadow-sm">
+      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-paper">
+        <Skeleton className="h-full w-full" />
+      </div>
+      <div className="flex grow flex-col gap-2 p-4">
+        <Skeleton className="h-5 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <div className="mt-auto flex gap-2">
+          <Skeleton className="h-5 w-16" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -1,69 +1,60 @@
 import React from "react";
-import { Card, CardContent, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import type { Mushroom } from "@/types";
+import { Badge } from "@/components/ui/badge";
+import { ChevronRight } from "lucide-react";
 
 interface Props {
   mushroom: Mushroom;
-  compact?: boolean;
-  onView: () => void;
-  onAdd: () => void;
-  onDetails: () => void;
+  onSelect: () => void;
+  disabled?: boolean;
 }
 
-export default function MushroomCard({ mushroom, compact = false, onView, onAdd, onDetails }: Props) {
+export default function MushroomCard({ mushroom, onSelect, disabled = false }: Props) {
   const handleKey = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") onDetails();
+    if (disabled) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect();
+    }
   };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!disabled) onSelect();
+  };
+
   return (
     <a
-      role="link"
       href="#"
-      onClick={(e) => {
-        e.preventDefault();
-        onDetails();
-      }}
+      role="link"
+      aria-label={mushroom.name}
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
       onKeyDown={handleKey}
-      className="block h-full no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+      onClick={handleClick}
+      className={`group relative h-full flex flex-col rounded-lg border border-border shadow-sm transition-transform transition-shadow duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 hover:shadow-md focus-visible:shadow-md hover:-translate-y-0.5 active:scale-[.99] ${disabled ? "pointer-events-none opacity-50" : ""}`}
     >
-      <Card className={compact ? "flex items-center gap-4 h-full" : "cursor-pointer h-full"}>
-        {compact ? (
-          <img
-            src={mushroom.photo}
-            alt=""
-            className="h-24 w-32 object-cover rounded-l-lg"
-            loading="lazy"
-          />
-        ) : (
-          <img
-            src={mushroom.photo}
-            alt=""
-            className="aspect-[4/3] w-full object-cover rounded-t-lg"
-            loading="lazy"
-          />
+      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-paper">
+        <img
+          src={mushroom.photo}
+          alt={mushroom.name}
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      </div>
+      <div className="flex grow flex-col gap-2 p-4">
+        <h3 className="truncate text-base font-medium text-foreground">{mushroom.name}</h3>
+        {mushroom.latin && (
+          <p className="truncate text-sm text-foreground/70">{mushroom.latin}</p>
         )}
-        <CardContent className={compact ? "p-4 flex-1" : "p-4 space-y-2"}>
-          <div className="flex items-center gap-2">
-            <CardTitle className="text-foreground text-lg font-semibold">{mushroom.name}</CardTitle>
-            {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
-          </div>
-          <p className="text-sm text-moss italic">{mushroom.latin}</p>
-          <div className="mt-2 flex flex-wrap gap-2">
-            <Button onClick={(e) => { e.stopPropagation(); onView(); }} className="text-sm py-1 px-2">
-              Voir sur la carte
-            </Button>
-            <Button
-              onClick={(e) => { e.stopPropagation(); onAdd(); }}
-              variant="secondary"
-              className="text-sm py-1 px-2"
-            >
-              Ajouter à mes coins
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+        <div className="mt-auto flex flex-wrap items-center gap-2">
+          {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
+          <ChevronRight
+            className="ml-auto h-4 w-4 text-foreground/40 transition-transform group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+        </div>
+      </div>
     </a>
   );
 }
-

--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { vi, describe, it, expect, beforeEach } from "vitest";
+import "@/index.css";
 
 import MushroomsIndex from "../index";
 import type { Mushroom } from "@/types";
@@ -77,31 +78,34 @@ describe("MushroomsIndex", () => {
     expect(cards[0]).toHaveTextContent("Morille");
   });
 
-  it("allows keyboard navigation", async () => {
-    render(<MushroomsIndex />);
-    await waitFor(() => screen.getByPlaceholderText("Rechercher"));
-    const search = screen.getByPlaceholderText("Rechercher");
-    (search as HTMLElement).focus();
-    expect(search).toHaveFocus();
-    const select = screen.getByDisplayValue("Toutes catégories");
-    (select as HTMLElement).focus();
-    expect(select).toHaveFocus();
-  });
-
-  it("renders cards as links", async () => {
+  it("card is focusable and activable via keyboard", async () => {
     render(<MushroomsIndex />);
     await waitFor(() => screen.getByRole("link", { name: /Cèpe/ }));
-    expect(screen.getByRole("link", { name: /Cèpe/ })).toBeInTheDocument();
+    const card = screen.getByRole("link", { name: /Cèpe/ });
+    card.focus();
+    expect(card).toHaveFocus();
+    fireEvent.keyDown(card, { key: "Enter" });
+    await waitFor(() => screen.getByRole("dialog"));
+  });
+
+  it("renders responsive columns", async () => {
+    render(<MushroomsIndex />);
+    await waitFor(() => screen.getByTestId("mushrooms-grid"));
+    const grid = screen.getByTestId("mushrooms-grid");
+    const classes = grid.className;
+    expect(classes).toContain("grid-cols-1");
+    expect(classes).toContain("sm:grid-cols-2");
+    expect(classes).toContain("lg:grid-cols-3");
+    expect(classes).toContain("xl:grid-cols-4");
   });
 
   it("shows loading and empty states", async () => {
     const { container } = render(<MushroomsIndex />);
     expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
-    await new Promise((r) => setTimeout(r, 0));
-    expect(screen.getAllByText("Cèpe")[0]).toBeInTheDocument();
+    await waitFor(() => screen.getByRole("link", { name: /Cèpe/ }));
     fireEvent.change(screen.getByPlaceholderText("Rechercher"), { target: { value: "xyz" } });
-    await new Promise(r => setTimeout(r,0));
-    expect(screen.getByText("Aucun champignon.")).toBeInTheDocument();
+    await waitFor(() => screen.getByText("Effacer filtres"));
+    expect(screen.getByText("Aucun résultat")).toBeInTheDocument();
   });
 });
 

--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -3,10 +3,9 @@ import { loadMushrooms } from "@/services/dataLoader";
 import type { Mushroom } from "@/types";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
-import { Tabs } from "@/components/ui/tabs";
-import { Skeleton } from "@/components/ui/skeleton";
 import SpeciesPicker, { SpeciesOption } from "@/components/mushrooms/SpeciesPicker";
 import MushroomCard from "@/components/mushrooms/MushroomCard";
+import MushroomCardSkeleton from "@/components/mushrooms/MushroomCard.skeleton";
 import MushroomDetails from "@/components/mushrooms/MushroomDetails";
 
 function normalize(str: string) {
@@ -49,7 +48,6 @@ export default function MushroomsIndex() {
   const [category, setCategory] = useState("all");
   const [access, setAccess] = useState("all");
   const [sort, setSort] = useState("alpha");
-  const [layout, setLayout] = useState("grid");
   const [selectedSpecies, setSelectedSpecies] = useState<string[]>([]);
   const [details, setDetails] = useState<Mushroom | null>(null);
   const [visible, setVisible] = useState(12);
@@ -119,17 +117,19 @@ export default function MushroomsIndex() {
 
   if (loading) {
     return (
-      <div className="p-4 grid-responsive">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="h-48" />
-        ))}
+      <div className="container py-4">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <MushroomCardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-4 space-y-4">
+      <div className="container py-4 space-y-4">
         <p className="text-foreground">Erreur de chargement.</p>
         <button
           className="underline text-foreground"
@@ -176,14 +176,6 @@ export default function MushroomsIndex() {
           <option value="alpha">Alphabétique</option>
           <option value="popular">Popularité</option>
         </Select>
-        <Tabs
-          tabs={[
-            { id: "grid", label: "Grille" },
-            { id: "list", label: "Liste" },
-          ]}
-          active={layout}
-          onChange={setLayout}
-        />
       </div>
 
       <SpeciesPicker
@@ -197,30 +189,29 @@ export default function MushroomsIndex() {
       />
 
       {filtered.length === 0 ? (
-        <p className="text-center text-foreground/70">Aucun champignon.</p>
-      ) : layout === "grid" ? (
-        <div className="grid-responsive">
-          {displayed.map((m) => (
-            <MushroomCard
-              key={m.id}
-              mushroom={m}
-              onView={() => setDetails(m)}
-              onAdd={() => setDetails(m)}
-              onDetails={() => setDetails(m)}
-            />
-          ))}
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
+          <div className="flex flex-col items-center justify-center rounded-lg border border-border p-6 text-center">
+            <p className="mb-2 text-foreground/70">Aucun résultat</p>
+            <button
+              className="underline"
+              onClick={() => {
+                setSearch("");
+                setCategory("all");
+                setAccess("all");
+                setSelectedSpecies([]);
+              }}
+            >
+              Effacer filtres
+            </button>
+          </div>
         </div>
       ) : (
-        <div className="flex flex-col gap-4">
+        <div
+          data-testid="mushrooms-grid"
+          className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]"
+        >
           {displayed.map((m) => (
-            <MushroomCard
-              key={m.id}
-              mushroom={m}
-              compact
-              onView={() => setDetails(m)}
-              onAdd={() => setDetails(m)}
-              onDetails={() => setDetails(m)}
-            />
+            <MushroomCard key={m.id} mushroom={m} onSelect={() => setDetails(m)} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- replace mushroom list with responsive grid of equal-height cards
- add accessible MushroomCard component and skeleton loader
- refine page loading/empty/error states and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3e7f68d48329bfecf1c5eab3783f