### PR TITLE
feat: tokenized latin styling for mushroom sheets

### DIFF
--- a/src/components/mushrooms/MushroomCard.skeleton.tsx
+++ b/src/components/mushrooms/MushroomCard.skeleton.tsx
@@ -7,9 +7,9 @@ export default function MushroomCardSkeleton() {
       <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-paper">
         <Skeleton className="h-full w-full" />
       </div>
-      <div className="flex grow flex-col gap-2 p-4">
+      <div className="flex grow flex-col p-4">
         <Skeleton className="h-5 w-3/4" />
-        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="mt-1 h-4 w-1/2" />
         <div className="mt-auto flex gap-2">
           <Skeleton className="h-5 w-16" />
         </div>

--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -42,10 +42,10 @@ export default function MushroomCard({ mushroom, onSelect, disabled = false }: P
           loading="lazy"
         />
       </div>
-      <div className="flex grow flex-col gap-2 p-4">
+      <div className="flex grow flex-col p-4">
         <h3 className="truncate text-base font-medium text-foreground">{mushroom.name}</h3>
         {mushroom.latin && (
-          <p className="truncate text-sm text-foreground/70">{mushroom.latin}</p>
+          <p className="mt-1 truncate text-sm italic text-[var(--muted-foreground)]">{mushroom.latin}</p>
         )}
         <div className="mt-auto flex flex-wrap items-center gap-2">
           {mushroom.premium && <Badge variant="secondary">Premium</Badge>}

--- a/src/components/mushrooms/MushroomDetails.tsx
+++ b/src/components/mushrooms/MushroomDetails.tsx
@@ -17,11 +17,13 @@ export default function MushroomDetails({ mushroom, open, onClose }: Props) {
       <div className="md:ml-auto md:h-full md:max-w-md md:w-full md:rounded-none overflow-y-auto">
         <img src={mushroom.photo} alt="" className="w-full aspect-[4/3] object-cover" loading="lazy" />
         <div className="p-4 space-y-4">
-          <div className="flex items-center gap-2">
-            <h2 className="text-xl font-semibold text-foreground">{mushroom.name}</h2>
-            {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-xl font-semibold text-foreground">{mushroom.name}</h2>
+              {mushroom.premium && <Badge variant="secondary">Premium</Badge>}
+            </div>
+            <p className="mt-1 truncate text-sm italic text-[var(--muted-foreground)]">{mushroom.latin}</p>
           </div>
-          <p className="text-sm text-moss italic">{mushroom.latin}</p>
           <p className="text-sm text-foreground/80">{mushroom.description}</p>
           <div className="flex gap-2">
             <Button onClick={onClose}>Voir sur la carte</Button>

--- a/src/components/mushrooms/__tests__/latinContrast.test.ts
+++ b/src/components/mushrooms/__tests__/latinContrast.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (0 <= h && h < 60) {
+    r = c;
+    g = x;
+  } else if (60 <= h && h < 120) {
+    r = x;
+    g = c;
+  } else if (120 <= h && h < 180) {
+    g = c;
+    b = x;
+  } else if (180 <= h && h < 240) {
+    g = x;
+    b = c;
+  } else if (240 <= h && h < 300) {
+    r = x;
+    b = c;
+  } else if (300 <= h && h < 360) {
+    r = c;
+    b = x;
+  }
+  return [r + m, g + m, b + m];
+}
+
+function luminance([r, g, b]: [number, number, number]) {
+  const a = [r, g, b].map((v) =>
+    v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+  );
+  return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
+}
+
+function contrast(hsl1: [number, number, number], hsl2: [number, number, number]) {
+  const L1 = luminance(hslToRgb(...hsl1));
+  const L2 = luminance(hslToRgb(...hsl2));
+  const [lighter, darker] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("Latin name contrast", () => {
+  it("muted foreground contrasts against card background", () => {
+    const muted: [number, number, number] = [137, 15, 36.5]; // --moss-green
+    const background: [number, number, number] = [37, 45, 92.2]; // --paper-beige
+    expect(contrast(muted, background)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,7 @@
 
     --background: var(--paper-beige);
     --foreground: var(--forest-green);
+    --muted-foreground: var(--moss-green);
     --border: 148 10% 70%;
     --accent: var(--accent-gold);
     --accent-hover: var(--accent-gold-hover);


### PR DESCRIPTION
## Summary
- style mushroom latin names with `--muted-foreground` token and italics
- add theme variable for muted foreground and adjust skeleton spacing
- ensure latin text passes AA contrast via test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c41ab9e6c8329981a5144bd55d0ca