### PR TITLE
feat: themed history view and harvest editor

### DIFF
--- a/src/components/harvest/EditHarvestModal.tsx
+++ b/src/components/harvest/EditHarvestModal.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from "react";
+import { Modal } from "@/components/ui/modal";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+
+type Harvest = {
+  id?: string;
+  date: string;
+  rating: number;
+  comment: string;
+  photos: string[];
+};
+
+export function EditHarvestModal({
+  open,
+  onClose,
+  onSave,
+  onDelete,
+  initial,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSave: (h: Harvest) => void;
+  onDelete?: () => void;
+  initial?: Harvest;
+}) {
+  const [date, setDate] = useState(initial?.date || "");
+  const [rating, setRating] = useState(initial?.rating ?? 0);
+  const [comment, setComment] = useState(initial?.comment || "");
+  const [photos, setPhotos] = useState<string[]>(initial?.photos || []);
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<{ date?: string }>({});
+
+  useEffect(() => {
+    setDate(initial?.date || "");
+    setRating(initial?.rating ?? 0);
+    setComment(initial?.comment || "");
+    setPhotos(initial?.photos || []);
+  }, [initial, open]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    if (open) window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const err: { date?: string } = {};
+    if (!date) err.date = "Requis";
+    setErrors(err);
+    if (Object.keys(err).length) return;
+    setLoading(true);
+    onSave({ id: initial?.id, date, rating, comment, photos });
+    setLoading(false);
+    onClose();
+  };
+
+  const importPhotos = (files: FileList | null) => {
+    if (!files) return;
+    const urls = Array.from(files).map(f => URL.createObjectURL(f));
+    setPhotos(p => [...p, ...urls]);
+  };
+
+  const removePhoto = (url: string) => {
+    if (confirm("Supprimer cette photo ?")) setPhotos(p => p.filter(u => u !== url));
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <h2 className="text-lg font-semibold">Modifier la cueillette</h2>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <label htmlFor="date" className="text-sm">
+              Date
+            </label>
+            <Input id="date" type="date" value={date} onChange={e => setDate(e.target.value)} />
+            {errors.date && <p className="text-xs text-danger">{errors.date}</p>}
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="rating" className="text-sm">
+              Note
+            </label>
+            <Select id="rating" value={String(rating)} onChange={e => setRating(parseInt(e.target.value, 10))}>
+              {[0, 1, 2, 3, 4, 5].map(n => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className="space-y-2 lg:col-span-2">
+            <label htmlFor="comment" className="text-sm">
+              Commentaire
+            </label>
+            <textarea
+              id="comment"
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              className="h-24 w-full rounded-md border border-border bg-paper px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            />
+          </div>
+          <div className="space-y-2 lg:col-span-2">
+            <label className="text-sm">Galerie</label>
+            <input
+              id="file"
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={e => importPhotos(e.target.files)}
+            />
+            <div className="flex flex-wrap gap-2">
+              {photos.map(url => (
+                <div key={url} className="relative w-24 h-24">
+                  <img src={url} className="w-full h-full object-cover rounded-md border border-border" alt="" />
+                  <button
+                    type="button"
+                    onClick={() => removePhoto(url)}
+                    className="absolute top-1 right-1 text-foreground/70 hover:text-foreground"
+                    aria-label="Supprimer"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+              <label
+                htmlFor="file"
+                className="w-24 h-24 flex items-center justify-center rounded-md border border-border cursor-pointer hover:bg-foreground/10 text-sm"
+              >
+                Importer des photos
+              </label>
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-2 flex-wrap mt-2">
+          {onDelete && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="text-danger border border-danger hover:bg-danger/10"
+              onClick={onDelete}
+            >
+              Supprimer
+            </Button>
+          )}
+          <div className="ml-auto flex gap-2 w-full sm:w-auto">
+            <Button type="button" variant="secondary" onClick={onClose} className="flex-1 sm:flex-none">
+              Annuler
+            </Button>
+            <Button type="submit" disabled={loading} className="flex-1 sm:flex-none">
+              {loading && (
+                <span className="mr-2 inline-block w-4 h-4 rounded-full border-2 border-border border-t-transparent animate-spin" />
+              )}
+              Enregistrer
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export default EditHarvestModal;
+

--- a/src/components/history/ChartSkeleton.tsx
+++ b/src/components/history/ChartSkeleton.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ChartSkeleton() {
+  return <Skeleton className="w-full h-56" />;
+}
+
+export default ChartSkeleton;

--- a/src/components/history/InsightsCard.tsx
+++ b/src/components/history/InsightsCard.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Tabs } from "@/components/ui/tabs";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts";
+import ChartSkeleton from "./ChartSkeleton";
+import { Timeline, TimelineEvent } from "./Timeline";
+import TimelineSkeleton from "./TimelineSkeleton";
+
+const tabs = [
+  { id: "history", label: "Historique" },
+  { id: "forecast", label: "Prévisions locales" },
+  { id: "visits", label: "Visites" },
+];
+
+function formatDate(str: string) {
+  const d = new Date(str);
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}`;
+}
+
+export function InsightsCard({ events, onSelect }: { events: TimelineEvent[]; onSelect: (id: string) => void }) {
+  const [active, setActive] = useState("history");
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<{ date: string; value: number }[]>([]);
+
+  useEffect(() => {
+    setLoading(true);
+    const timer = setTimeout(() => {
+      const now = new Date();
+      const d = Array.from({ length: 10 }).map((_, i) => ({
+        date: new Date(now.getTime() - (9 - i) * 86400000).toISOString().slice(0, 10),
+        value: (i * 10) % 100,
+      }));
+      setData(d);
+      setLoading(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [active]);
+
+  const ticks = data.length
+    ? data
+        .filter((_, i) => i % Math.ceil(data.length / 6) === 0)
+        .map(d => d.date)
+    : [];
+
+  return (
+    <Card className="p-4 lg:p-6 flex flex-col">
+      <CardHeader className="p-0 mb-4 border-none">
+        <CardTitle>Insights</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 flex-1 flex flex-col">
+        <Tabs tabs={tabs} active={active} onChange={setActive} />
+        <div className="mt-4" style={{ height: 240 }}>
+          {loading ? (
+            <ChartSkeleton />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="3 3" />
+                <XAxis dataKey="date" ticks={ticks} tickFormatter={formatDate} stroke="hsl(var(--foreground))" tick={{ fill: "hsl(var(--foreground))" }} />
+                <YAxis domain={[0, 100]} stroke="hsl(var(--foreground))" tick={{ fill: "hsl(var(--foreground))" }} />
+                <Tooltip contentStyle={{ background: "hsl(var(--background))", border: "1px solid hsl(var(--border))", borderRadius: 4 }} labelFormatter={(v) => formatDate(v as string)} />
+                <Line type="monotone" dataKey="value" stroke="hsl(var(--forest-green))" strokeWidth={2} dot={false} isAnimationActive={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+        <div className="mt-4 flex-1 overflow-auto">
+          {loading ? <TimelineSkeleton /> : <Timeline events={events} onSelect={onSelect} />}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default InsightsCard;

--- a/src/components/history/MapCard.tsx
+++ b/src/components/history/MapCard.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { loadMap } from "@/services/openstreetmap";
+import type { StyleSpecification } from "maplibre-gl";
+
+export function MapCard({ center }: { center: [number, number] }) {
+  const mapContainer = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<any>(null);
+  useEffect(() => {
+    if (!mapContainer.current) return;
+    const [lat, lng] = center;
+    loadMap().then(maplibregl => {
+      const style: StyleSpecification = {
+        version: 8,
+        sources: {
+          osm: {
+            type: "raster",
+            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+            tileSize: 256,
+            attribution: "© OpenStreetMap contributors | MapLibre",
+          },
+        },
+        layers: [
+          {
+            id: "osm",
+            type: "raster",
+            source: "osm",
+            minzoom: 0,
+            maxzoom: 19,
+          },
+        ],
+      };
+      const map = new maplibregl.Map({
+        container: mapContainer.current as HTMLDivElement,
+        style,
+        center: [lng, lat],
+        zoom: 12,
+        attributionControl: false,
+      });
+      mapRef.current = map;
+      new maplibregl.Marker().setLngLat([lng, lat]).addTo(map);
+    });
+    return () => mapRef.current?.remove();
+  }, [center]);
+  return (
+    <Card className="p-4 lg:p-6">
+      <CardHeader className="p-0 mb-4 border-none">
+        <CardTitle>Carte du coin</CardTitle>
+        <p className="text-sm text-foreground/70">La carte affiche l’historique complet avec détails.</p>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="relative w-full rounded-md border border-border overflow-hidden aspect-video">
+          <div ref={mapContainer} className="absolute inset-0" />
+        </div>
+        <div className="mt-2 text-[10px] text-foreground/50 text-right">© OpenStreetMap contributors | MapLibre</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default MapCard;

--- a/src/components/history/Timeline.tsx
+++ b/src/components/history/Timeline.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export type TimelineEvent = {
+  id: string;
+  date: string;
+  rating: number;
+  label: string;
+};
+
+export function Timeline({ events, onSelect }: { events: TimelineEvent[]; onSelect: (id: string) => void }) {
+  return (
+    <div className="space-y-2">
+      {events.map(ev => (
+        <button
+          key={ev.id}
+          onClick={() => onSelect(ev.id)}
+          className="flex w-full items-center gap-4 h-12 px-4 rounded-md text-left text-sm hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <span className="flex-1">{ev.date}</span>
+          <span className="w-12 text-center">{ev.rating}</span>
+          <span className="flex-1">{ev.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default Timeline;

--- a/src/components/history/TimelineSkeleton.tsx
+++ b/src/components/history/TimelineSkeleton.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function TimelineSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-12 w-full" />
+      ))}
+    </div>
+  );
+}
+
+export default TimelineSkeleton;

--- a/src/routes/spots/History.test.tsx
+++ b/src/routes/spots/History.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import History from "./History";
+
+function setScreenWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("max-width") ? width <= 1023 : width >= 1024,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe("History page", () => {
+  beforeEach(() => {
+    vi.mock("@/services/openstreetmap", () => ({
+      loadMap: vi.fn(async () => ({
+        Map: class {
+          remove() {}
+        },
+        Marker: class {
+          setLngLat() {
+            return this;
+          }
+          addTo() {
+            return this;
+          }
+        },
+      })),
+    }));
+    vi.mock("recharts", () => {
+      const React = require("react");
+      const Mock = ({ children }: any) => <div>{children}</div>;
+      return {
+        ResponsiveContainer: Mock,
+        LineChart: Mock,
+        Line: Mock,
+        XAxis: Mock,
+        YAxis: Mock,
+        CartesianGrid: Mock,
+        Tooltip: Mock,
+      };
+    });
+  });
+
+  it("renders bottom CTA on mobile", () => {
+    setScreenWidth(500);
+    render(<History />);
+    expect(screen.getAllByText("Ajouter une cueillette").length).toBe(2);
+  });
+
+  it("hides bottom CTA on desktop", () => {
+    setScreenWidth(1200);
+    render(<History />);
+    expect(screen.getAllByText("Ajouter une cueillette").length).toBe(1);
+  });
+
+  it("opens and closes modal", () => {
+    setScreenWidth(1200);
+    render(<History />);
+    fireEvent.click(screen.getByText("Ajouter une cueillette"));
+    expect(screen.getByText("Modifier la cueillette")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByText("Modifier la cueillette")).not.toBeInTheDocument();
+  });
+
+  it("validates form fields", () => {
+    setScreenWidth(1200);
+    render(<History />);
+    fireEvent.click(screen.getByText("Ajouter une cueillette"));
+    const save = screen.getByText("Enregistrer");
+    fireEvent.click(save);
+    expect(screen.getByText("Requis")).toBeInTheDocument();
+  });
+
+  it("opens modal via keyboard on timeline", async () => {
+    setScreenWidth(1200);
+    render(<History />);
+    const rowText = await screen.findByText("01/09/2024");
+    const row = rowText.closest("button") as HTMLButtonElement;
+    row.focus();
+    fireEvent.keyDown(row, { key: "Enter", code: "Enter", charCode: 13 });
+    fireEvent.click(row);
+    expect(screen.getByText("Modifier la cueillette")).toBeInTheDocument();
+  });
+});

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import MapCard from "@/components/history/MapCard";
+import InsightsCard from "@/components/history/InsightsCard";
+import EditHarvestModal from "@/components/harvest/EditHarvestModal";
+import { TimelineEvent } from "@/components/history/Timeline";
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = React.useState(() => window.matchMedia(query).matches);
+  React.useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+  return matches;
+}
+
+export default function History() {
+  const events: TimelineEvent[] = [
+    { id: "1", date: "01/09/2024", rating: 3, label: "Création" },
+    { id: "2", date: "10/09/2024", rating: 4, label: "Visite" },
+  ];
+  const [editing, setEditing] = useState<TimelineEvent | null>(null);
+  const isMobile = useMediaQuery("(max-width: 1023px)");
+
+  return (
+    <section className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Historique du coin</h1>
+        <Button onClick={() => setEditing({ id: "", date: "", rating: 0, label: "" })}>Ajouter une cueillette</Button>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <MapCard center={[48.8566, 2.3522]} />
+        <InsightsCard events={events} onSelect={id => setEditing(events.find(e => e.id === id) || null)} />
+      </div>
+      {isMobile && (
+        <div>
+          <Button className="w-full" onClick={() => setEditing({ id: "", date: "", rating: 0, label: "" })}>
+            Ajouter une cueillette
+          </Button>
+        </div>
+      )}
+      <EditHarvestModal
+        open={editing !== null}
+        initial={editing ? { date: editing.date, rating: editing.rating, comment: "", photos: [] } : undefined}
+        onClose={() => setEditing(null)}
+        onSave={() => setEditing(null)}
+        onDelete={editing && editing.id ? () => setEditing(null) : undefined}
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add responsive history page with map and insight cards
- style chart/timeline with tokens and skeletons
- introduce edit harvest modal with gallery and validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c40636140832982d4de301d9dbd23