### PR TITLE
Use replaceState to prevent double back in settings

### DIFF
--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -31,7 +31,12 @@ export default function SettingsIndex() {
   ];
 
   useEffect(() => {
-    if (active) window.location.hash = active;
+    if (active) {
+      const hash = `#${active}`;
+      if (window.location.hash !== hash) {
+        window.history.replaceState(null, '', hash);
+      }
+    }
   }, [active]);
 
   return (


### PR DESCRIPTION
## Summary
- avoid pushing duplicate history entries when changing settings tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c439aa7dc8329b8d0a5e20a153e7e