### PR TITLE
Fix double back requirement in Settings

### DIFF
--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -31,7 +31,9 @@ export default function SettingsIndex() {
   ];
 
   useEffect(() => {
-    if (active) window.location.hash = active;
+    if (active) {
+      window.history.replaceState(null, '', `${window.location.pathname}#${active}`);
+    }
   }, [active]);
 
   return (


### PR DESCRIPTION
## Summary
- avoid adding history entries when switching settings tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c439aa7dc8329b8d0a5e20a153e7e