### PR TITLE
style: replace latin badge with muted paragraph

### DIFF
--- a/src/scenes/MushroomScene.tsx
+++ b/src/scenes/MushroomScene.tsx
@@ -27,7 +27,9 @@ export default function MushroomScene({ item, onSeeZones, onBack }: { item: Mush
         <div className="p-4 space-y-4">
           <div className="flex flex-wrap items-center gap-2">
             <h2 className={`text-xl font-semibold ${T_PRIMARY}`}>{item.name}</h2>
-            <Badge variant="secondary">{item.latin}</Badge>
+            <p className="mt-1 text-sm italic text-[var(--muted-foreground)] truncate">
+              {item.latin}
+            </p>
             {item.edible ? (
               <Badge className="bg-emerald-700">🍴 {t("comestible")}</Badge>
             ) : (


### PR DESCRIPTION
## Summary
- show mushroom latin name in muted italic paragraph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c45349ab883298fe05f48a4b51831