### PR TITLE
Include location when adding zones as spots

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,7 @@ function AppContent() {
                           13
                         )
                       : MUSHROOMS[1].photo;
+                    const location = selectedZone?.coords?.join(",");
                     dispatch({
                       type: "addSpot",
                       spot: {
@@ -169,6 +170,7 @@ function AppContent() {
                         species: Object.keys(selectedZone?.species || {}),
                         rating: 5,
                         last: today,
+                        location,
                         history: [
                           { date: today, rating: 5, note: t("Créé"), photos: [cover] },
                         ],


### PR DESCRIPTION
## Summary
- Save coordinates as location when converting a zone to a spot
- Enables showing center logo on spot cards that display map previews

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c76f294b08329aacd5d240cdea6f0