### PR TITLE
Refine history timeline and harvest gallery

### DIFF
--- a/src/components/harvest/EditHarvestModal.tsx
+++ b/src/components/harvest/EditHarvestModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from "@/components/ui/modal";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Trash2 } from "lucide-react";
 
 type Harvest = {
   id?: string;
@@ -106,6 +107,23 @@ export function EditHarvestModal({
           </div>
           <div className="space-y-2 lg:col-span-2">
             <label className="text-sm">Galerie</label>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {photos.map(url => (
+                <div key={url} className="relative aspect-square">
+                  <img src={url} className="w-full h-full object-cover rounded-md border border-border" alt="" />
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="destructive"
+                    className="absolute top-1 right-1 h-6 w-6 p-0"
+                    onClick={() => removePhoto(url)}
+                    aria-label="Supprimer"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
             <input
               id="file"
               type="file"
@@ -114,27 +132,13 @@ export function EditHarvestModal({
               className="hidden"
               onChange={e => importPhotos(e.target.files)}
             />
-            <div className="flex flex-wrap gap-2">
-              {photos.map(url => (
-                <div key={url} className="relative w-24 h-24">
-                  <img src={url} className="w-full h-full object-cover rounded-md border border-border" alt="" />
-                  <button
-                    type="button"
-                    onClick={() => removePhoto(url)}
-                    className="absolute top-1 right-1 text-foreground/70 hover:text-foreground"
-                    aria-label="Supprimer"
-                  >
-                    ×
-                  </button>
-                </div>
-              ))}
-              <label
-                htmlFor="file"
-                className="w-24 h-24 flex items-center justify-center rounded-md border border-border cursor-pointer hover:bg-foreground/10 text-sm"
-              >
-                Importer des photos
-              </label>
-            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => document.getElementById("file")?.click()}
+            >
+              Importer des photos
+            </Button>
           </div>
         </div>
         <div className="flex items-center justify-between gap-2 flex-wrap mt-2">

--- a/src/components/history/MapCard.tsx
+++ b/src/components/history/MapCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
 import { loadMap } from "@/services/openstreetmap";
 import type { StyleSpecification } from "maplibre-gl";
 
@@ -52,8 +52,10 @@ export function MapCard({ center }: { center: [number, number] }) {
         <div className="relative w-full rounded-md border border-border overflow-hidden aspect-video">
           <div ref={mapContainer} className="absolute inset-0" />
         </div>
-        <div className="mt-2 text-[10px] text-foreground/50 text-right">© OpenStreetMap contributors | MapLibre</div>
       </CardContent>
+      <CardFooter className="pt-2 flex justify-end">
+        <p className="text-xs text-foreground/50">© OpenStreetMap contributors | MapLibre</p>
+      </CardFooter>
     </Card>
   );
 }

--- a/src/components/history/Timeline.tsx
+++ b/src/components/history/Timeline.tsx
@@ -14,11 +14,12 @@ export function Timeline({ events, onSelect }: { events: TimelineEvent[]; onSele
         <button
           key={ev.id}
           onClick={() => onSelect(ev.id)}
-          className="flex w-full items-center gap-4 h-12 px-4 rounded-md text-left text-sm hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="flex items-center w-full h-12 px-4 rounded-md text-left hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
-          <span className="flex-1">{ev.date}</span>
-          <span className="w-12 text-center">{ev.rating}</span>
-          <span className="flex-1">{ev.label}</span>
+          <div className="flex flex-col">
+            <span className="text-sm">{ev.date}</span>
+            <span className="text-xs text-foreground/70">Note: {ev.rating}/5{ev.label ? ` • ${ev.label}` : ""}</span>
+          </div>
         </button>
       ))}
     </div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -18,3 +18,7 @@ export function CardContent({ className = "", ...props }: React.HTMLAttributes<H
   return <div className={`p-4 ${className}`} {...props} />;
 }
 
+export function CardFooter({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`p-4 border-t border-border ${className}`} {...props} />;
+}
+


### PR DESCRIPTION
## Summary
- align map attribution with a card footer and theme tokens
- streamline timeline rows with descriptive note formatting
- add responsive gallery grid with delete controls in harvest modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c765112548329b81e319d098d9f10