### PR TITLE
Refactor mushrooms page into responsive card grid

### DIFF
--- a/src/components/mushrooms/MushroomCard.skeleton.tsx
+++ b/src/components/mushrooms/MushroomCard.skeleton.tsx
@@ -3,13 +3,13 @@ import Skeleton from "@/components/ui/skeleton";
 
 export default function MushroomCardSkeleton() {
   return (
-    <div className="h-full flex flex-col rounded-lg border border-border shadow-sm">
-      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-paper">
+    <div className="h-full flex flex-col rounded-lg border border-border bg-paper shadow-sm">
+      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-[var(--surface-2)]">
         <Skeleton className="h-full w-full" />
       </div>
-      <div className="flex grow flex-col p-4">
+      <div className="flex grow flex-col gap-2 p-4">
         <Skeleton className="h-5 w-3/4" />
-        <Skeleton className="mt-1 h-4 w-1/2" />
+        <Skeleton className="h-4 w-1/2" />
         <div className="mt-auto flex gap-2">
           <Skeleton className="h-5 w-16" />
         </div>

--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -32,9 +32,9 @@ export default function MushroomCard({ mushroom, onSelect, disabled = false }: P
       aria-disabled={disabled}
       onKeyDown={handleKey}
       onClick={handleClick}
-      className={`group relative h-full flex flex-col rounded-lg border border-border shadow-sm transition-transform transition-shadow duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 hover:shadow-md focus-visible:shadow-md hover:-translate-y-0.5 active:scale-[.99] ${disabled ? "pointer-events-none opacity-50" : ""}`}
+      className={`group relative h-full flex flex-col rounded-lg border border-border bg-paper text-foreground shadow-sm transition hover:shadow-md focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:-translate-y-0.5 active:scale-[.99] ${disabled ? "pointer-events-none opacity-50" : ""}`}
     >
-      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-paper">
+      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-[var(--surface-2)]">
         <img
           src={mushroom.photo}
           alt={mushroom.name}
@@ -42,10 +42,10 @@ export default function MushroomCard({ mushroom, onSelect, disabled = false }: P
           loading="lazy"
         />
       </div>
-      <div className="flex grow flex-col p-4">
-        <h3 className="truncate text-base font-medium text-foreground">{mushroom.name}</h3>
+      <div className="flex grow flex-col gap-2 p-4">
+        <h3 className="text-base font-medium truncate">{mushroom.name}</h3>
         {mushroom.latin && (
-          <p className="mt-1 truncate text-sm italic text-[var(--muted-foreground)]">{mushroom.latin}</p>
+          <p className="text-sm text-[var(--muted-foreground)] truncate">{mushroom.latin}</p>
         )}
         <div className="mt-auto flex flex-wrap items-center gap-2">
           {mushroom.premium && <Badge variant="secondary">Premium</Badge>}

--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -84,7 +84,17 @@ describe("MushroomsIndex", () => {
     const card = screen.getByRole("link", { name: /Cèpe/ });
     card.focus();
     expect(card).toHaveFocus();
+    expect(card.className).toContain("focus-visible:ring-[var(--focus)]");
     fireEvent.keyDown(card, { key: "Enter" });
+    await waitFor(() => screen.getByRole("dialog"));
+  });
+
+  it("activates card with Space key", async () => {
+    render(<MushroomsIndex />);
+    await waitFor(() => screen.getByRole("link", { name: /Cèpe/ }));
+    const card = screen.getByRole("link", { name: /Cèpe/ });
+    card.focus();
+    fireEvent.keyDown(card, { key: " " });
     await waitFor(() => screen.getByRole("dialog"));
   });
 
@@ -108,4 +118,3 @@ describe("MushroomsIndex", () => {
     expect(screen.getByText("Aucun résultat")).toBeInTheDocument();
   });
 });
-

--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -117,7 +117,7 @@ export default function MushroomsIndex() {
 
   if (loading) {
     return (
-      <div className="container py-4">
+      <div className="container px-4 py-4">
         <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
           {Array.from({ length: 8 }).map((_, i) => (
             <MushroomCardSkeleton key={i} />
@@ -129,7 +129,7 @@ export default function MushroomsIndex() {
 
   if (error) {
     return (
-      <div className="container py-4 space-y-4">
+      <div className="container px-4 py-4 space-y-4">
         <p className="text-foreground">Erreur de chargement.</p>
         <button
           className="underline text-foreground"
@@ -151,7 +151,7 @@ export default function MushroomsIndex() {
   }
 
   return (
-    <div className="container py-4 space-y-4">
+    <div className="container px-4 py-4 space-y-4">
       <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-4">
         <Input
           placeholder="Rechercher"


### PR DESCRIPTION
## Summary
- refactor MushroomCard with uniform focus ring, 4:3 media ratio, and spacing
- style MushroomCard skeleton and page container for consistent grid layout
- add keyboard activation tests and ensure responsive grid classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c76159e608329891373f8dd97884f