### PR TITLE
Refactor toast notifications with motion design

### DIFF
--- a/src/components/ui/__tests__/toast.test.tsx
+++ b/src/components/ui/__tests__/toast.test.tsx
@@ -51,6 +51,24 @@ describe('toast system', () => {
     vi.useRealTimers();
   });
 
+  it('reorders when a toast disappears', () => {
+    vi.useFakeTimers();
+    render(<Toaster />);
+    act(() => {
+      toast.show({ message: 'A', duration: 3000 });
+      toast.show({ message: 'B', duration: 1000 });
+    });
+    let items = screen.getAllByRole('status');
+    expect(items[0]).toHaveTextContent('B');
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    items = screen.getAllByRole('status');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('A');
+    vi.useRealTimers();
+  });
+
   it('honors prefers-reduced-motion', () => {
     useReducedMotionMock.mockReturnValue(true);
     render(<Toaster />);

--- a/src/styles/toast.css
+++ b/src/styles/toast.css
@@ -6,7 +6,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .toast-reduced {
+  [data-reduced='true'] {
     transition: none !important;
     animation: none !important;
   }


### PR DESCRIPTION
## Summary
- animate toast stack with fade/slide/scale and staggered entries while respecting `prefers-reduced-motion`
- cleanly stack toasts in fixed container with aria-live region
- add reduced-motion styles and reordering test coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7832933483299a83e90e7abc860d