### PR TITLE
feat(toast): animate overflow removal

### DIFF
--- a/src/components/ui/__tests__/toast.test.tsx
+++ b/src/components/ui/__tests__/toast.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Toaster } from '../Toaster';
@@ -21,7 +21,7 @@ describe('toast system', () => {
     useReducedMotionMock.mockReturnValue(false);
   });
 
-  it('respects order and max stack', () => {
+  it('respects order and max stack', async () => {
     render(<Toaster />);
     act(() => {
       toast.show({ message: 'A' });
@@ -29,10 +29,12 @@ describe('toast system', () => {
       toast.show({ message: 'C' });
       toast.show({ message: 'D' });
     });
-    const items = screen.getAllByRole('status');
-    expect(items).toHaveLength(3);
-    expect(items[0]).toHaveTextContent('D');
-    expect(items[2]).toHaveTextContent('B');
+    await waitFor(() => {
+      const items = screen.getAllByRole('status');
+      expect(items).toHaveLength(3);
+      expect(items[0]).toHaveTextContent('D');
+      expect(items[2]).toHaveTextContent('B');
+    });
   });
 
   it('auto dismisses with pause on hover', () => {

--- a/src/components/ui/toast.ts
+++ b/src/components/ui/toast.ts
@@ -31,7 +31,15 @@ export const useToastStore = create<ToastStore>((set, get) => ({
   show: toast => {
     const id = nextId();
     const max = get().max;
-    set(state => ({ toasts: [{ id, ...toast }, ...state.toasts].slice(0, max) }));
+    set(state => {
+      const toasts = [{ id, ...toast }, ...state.toasts];
+      if (toasts.length > max) {
+        const overflow = toasts[max];
+        // keep overflow item for exit animation then remove next tick
+        setTimeout(() => get().dismiss(overflow.id), 0);
+      }
+      return { toasts: toasts.slice(0, max + 1) };
+    });
     return id;
   },
   dismiss: id => {


### PR DESCRIPTION
## Summary
- allow max-stack overflow toast to exit with animation before removal
- adjust tests to wait for async pruning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c7c930b308329900f15b39c98947b