### PR TITLE
feat: improve toast accessibility and motion

### DIFF
--- a/src/components/ui/Toaster.tsx
+++ b/src/components/ui/Toaster.tsx
@@ -125,7 +125,7 @@ function ToastView({ toast: t, index }: { toast: ToastItem; index: number }) {
             }
           : {
               opacity: 0,
-              y: -16,
+              y: 16,
               scale: 0.96,
               height: 0,
               marginBottom: 0,
@@ -152,7 +152,6 @@ function ToastView({ toast: t, index }: { toast: ToastItem; index: number }) {
             }
       }
       role={variantRole[t.variant ?? 'info'] as any}
-      aria-live={t.variant === 'error' ? 'assertive' : 'polite'}
       data-reduced={reduced}
       className={classes}
     >
@@ -194,12 +193,13 @@ export function Toaster({
   useEffect(() => setMax(max), [max, setMax]);
 
   const posClass = `${POS[position.mobile]} md:${POS[position.desktop]}`;
+  const live = toasts.some(t => t.variant === 'error') ? 'assertive' : 'polite';
 
   return createPortal(
     <div
       className={`fixed z-50 flex flex-col gap-2 pointer-events-none ${posClass}`}
       role="region"
-      aria-live="polite"
+      aria-live={live}
     >
       <AnimatePresence initial={false}>
         {toasts.map((t, i) => (

--- a/src/components/ui/__tests__/toast.test.tsx
+++ b/src/components/ui/__tests__/toast.test.tsx
@@ -86,4 +86,14 @@ describe('toast system', () => {
     fireEvent.keyDown(action, { key: 'Escape' });
     expect(screen.queryByText('Act')).toBeNull();
   });
+
+  it('uses assertive live region for error toasts', () => {
+    render(<Toaster />);
+    const region = screen.getByRole('region');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    act(() => {
+      toast.show({ message: 'Oops', variant: 'error', duration: 1000 });
+    });
+    expect(region).toHaveAttribute('aria-live', 'assertive');
+  });
 });


### PR DESCRIPTION
## Summary
- refine toast exit animation to slide down and collapse
- use assertive live region when displaying error toasts
- test live region behaviour for error toasts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c7c930b308329900f15b39c98947b