### PR TITLE
fix: center static map thumbnails

### DIFF
--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -89,11 +89,11 @@ export default function SpotsScene({ onBack, onOpenSpot }: { onBack: () => void;
               >
                 {hasLoc ? (
                   <div className="relative w-full h-40">
-                    <img src={mapUrl as string} className="w-full h-full object-cover" />
+                    <img src={mapUrl as string} className="w-full h-full object-cover object-center" />
                     <img src={Logo} className="w-6 h-6 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
                   </div>
                 ) : (
-                  <img src={mapUrl as string} className="w-full h-40 object-cover" />
+                  <img src={mapUrl as string} className="w-full h-40 object-cover object-center" />
                 )}
                 <button
                   onClick={(e) => {

--- a/src/services/openstreetmap.test.ts
+++ b/src/services/openstreetmap.test.ts
@@ -24,9 +24,10 @@ describe('reverseGeocode', () => {
 });
 
 describe('getStaticMapUrl', () => {
-  it('uses Carto tiles with retina suffix when width is large', () => {
+  it('builds a centered OpenStreetMap static map URL', () => {
     const url = getStaticMapUrl(48.8566, 2.3522, 400, 200, 13);
-    expect(url).toMatch(/basemaps\.cartocdn\.com/);
-    expect(url).toMatch(/@2x\.png$/);
+    expect(url).toBe(
+      'https://staticmap.openstreetmap.de/staticmap.php?center=48.8566%2C2.3522&zoom=13&size=400x200&maptype=mapnik'
+    );
   });
 });

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -6,21 +6,12 @@ export async function loadMap() {
 }
 
 export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 160, zoom = 13) {
-  // Build a static tile URL using the same provider as the interactive map
-  // (Carto "positron" style). We compute the tile x/y for the given lat/lng
-  // and zoom and request a high‑resolution variant depending on the requested
-  // width/height. Carto tiles support a "@2x" suffix for retina displays. We
-  // choose the scale so that the returned image is at least as big as the
-  // requested size, capped at 2× to match provider capabilities.
-  const xtile = Math.floor(((lng + 180) / 360) * Math.pow(2, zoom));
-  const ytile = Math.floor(
-    ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
-      Math.pow(2, zoom)
-  );
-  const scale = Math.min(2, Math.ceil(Math.max(width, height) / 256));
-  const suffix = scale > 1 ? `@${scale}x` : "";
-  const sub = ["a", "b", "c", "d"][Math.floor(Math.random() * 4)];
-  return `https://${sub}.basemaps.cartocdn.com/light_all/${zoom}/${xtile}/${ytile}${suffix}.png`;
+  const url = new URL("https://staticmap.openstreetmap.de/staticmap.php");
+  url.searchParams.set("center", `${lat},${lng}`);
+  url.searchParams.set("zoom", String(zoom));
+  url.searchParams.set("size", `${Math.round(width)}x${Math.round(height)}`);
+  url.searchParams.set("maptype", "mapnik");
+  return url.toString();
 }
 
 export async function geocode(query: string) {


### PR DESCRIPTION
## Summary
- use OpenStreetMap static map service to keep thumbnails centered on chosen coordinates
- ensure responsive thumbnails stay centered with `object-center`
- update static map tests for new centered URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7aca90c88329acc96fb605c50f6e