### PR TITLE
fix: center static map thumbnails

### DIFF
--- a/src/services/openstreetmap.test.ts
+++ b/src/services/openstreetmap.test.ts
@@ -24,9 +24,8 @@ describe('reverseGeocode', () => {
 });
 
 describe('getStaticMapUrl', () => {
-  it('uses Carto tiles with retina suffix when width is large', () => {
+  it('builds a Carto tile URL keeping map style', () => {
     const url = getStaticMapUrl(48.8566, 2.3522, 400, 200, 13);
-    expect(url).toMatch(/basemaps\.cartocdn\.com/);
-    expect(url).toMatch(/@2x\.png$/);
+    expect(url).toMatch(/^https:\/\/[abcd]\.basemaps\.cartocdn\.com\/light_all\/13\/4150\/2818@2x\.png$/);
   });
 });

--- a/src/services/openstreetmap.ts
+++ b/src/services/openstreetmap.ts
@@ -6,17 +6,16 @@ export async function loadMap() {
 }
 
 export function getStaticMapUrl(lat: number, lng: number, width = 400, height = 160, zoom = 13) {
-  // Build a static tile URL using the same provider as the interactive map
-  // (Carto "positron" style). We compute the tile x/y for the given lat/lng
-  // and zoom and request a high‑resolution variant depending on the requested
-  // width/height. Carto tiles support a "@2x" suffix for retina displays. We
-  // choose the scale so that the returned image is at least as big as the
-  // requested size, capped at 2× to match provider capabilities.
-  const xtile = Math.floor(((lng + 180) / 360) * Math.pow(2, zoom));
-  const ytile = Math.floor(
+  // Build a static tile URL using the same Carto "positron" style as the
+  // interactive map. We pick the tile whose center is closest to the given
+  // coordinates so that the returned image shows roughly centered content
+  // without changing map style.
+  const xtileF = ((lng + 180) / 360) * Math.pow(2, zoom);
+  const ytileF =
     ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
-      Math.pow(2, zoom)
-  );
+    Math.pow(2, zoom);
+  const xtile = Math.round(xtileF);
+  const ytile = Math.round(ytileF);
   const scale = Math.min(2, Math.ceil(Math.max(width, height) / 256));
   const suffix = scale > 1 ? `@${scale}x` : "";
   const sub = ["a", "b", "c", "d"][Math.floor(Math.random() * 4)];


### PR DESCRIPTION
## Summary
- select Carto tile nearest to chosen coordinates to keep map style
- update static map tests for Carto tile URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c7aca90c88329acc96fb605c50f6e