### PR TITLE
Remove reduced motion media queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CSS variables are defined in [`src/index.css`](src/index.css) so Tailwind utilit
 New primitive components live in [`src/components/ui`](src/components/ui): buttons, inputs, selects, tabs, chips, cards, modals and toasts.  Buttons support `primary`, `secondary`, `ghost` and `destructive` variants with accessible focus styles.  Cards and chips include subtle hover lift and rounded organic forms.  A lightweight `Skeleton` component provides loading placeholders.
 
 ## Global Styles & Layout
-`src/index.css` applies a reset, theming variables, a lightweight grain texture and container/grid utilities.  Motion respects `prefers-reduced-motion` and all colors meet WCAG AA contrast.
+`src/index.css` applies a reset, theming variables, a lightweight grain texture and container/grid utilities.  All colors meet WCAG AA contrast.
 
 ## Map & Scenes
 The map scene uses the natural palette for tinting and hides default chrome for a cleaner look.  The landing hero now relies solely on organic blobs and color, removing literal mushroom graphics.

--- a/src/index.css
+++ b/src/index.css
@@ -79,9 +79,6 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
     mix-blend-mode:overlay;
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after { transition-duration:0ms!important; animation-duration:0ms!important; }
-  }
 }
 
 @layer base {

--- a/src/styles/toast.css
+++ b/src/styles/toast.css
@@ -5,9 +5,3 @@
   .toast-error { @apply bg-danger text-paper; }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  [data-reduced='true'] {
-    transition: none !important;
-    animation: none !important;
-  }
-}


### PR DESCRIPTION
## Summary
- remove prefers-reduced-motion media query from global styles
- drop reduced-motion query from toast styles
- update README to no longer reference reduced-motion support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c8976e0f08329bc941ed92e18fd6c