### PR TITLE
Generate static map thumbnails from tiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@napi-rs/canvas": "^0.1.77",
         "@tailwindcss/postcss": "^4.1.11",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -1193,6 +1194,201 @@
       },
       "bin": {
         "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.77.tgz",
+      "integrity": "sha512-N9w2DkEKE1AXGp3q55GBOP6BEoFrqChDiFqJtKViTpQCWNOSVuMz7LkoGehbnpxtidppbsC36P0kCZNqJKs29w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.77",
+        "@napi-rs/canvas-darwin-arm64": "0.1.77",
+        "@napi-rs/canvas-darwin-x64": "0.1.77",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.77",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.77",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.77",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.77",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.77",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.77",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.77"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.77.tgz",
+      "integrity": "sha512-jC8YX0rbAnu9YrLK1A52KM2HX9EDjrJSCLVuBf9Dsov4IC6GgwMLS2pwL9GFLJnSZBFgdwnA84efBehHT9eshA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.77.tgz",
+      "integrity": "sha512-VFaCaCgAV0+hPwXajDIiHaaGx4fVCuUVYp/CxCGXmTGz699ngIEBx3Sa2oDp0uk3X+6RCRLueb7vD44BKBiPIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.77.tgz",
+      "integrity": "sha512-uD2NSkf6I4S3o0POJDwweK85FE4rfLNA2N714MgiEEMMw5AmupfSJGgpYzcyEXtPzdaca6rBfKcqNvzR1+EyLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.77.tgz",
+      "integrity": "sha512-03GxMMZGhHRQxiA4gyoKT6iQSz8xnA6T9PAfg/WNJnbkVMFZG782DwUJUb39QIZ1uE1euMCPnDgWAJ092MmgJQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.77.tgz",
+      "integrity": "sha512-ZO+d2gRU9JU1Bb7SgJcJ1k9wtRMCpSWjJAJ+2phhu0Lw5As8jYXXXmLKmMTGs1bOya2dBMYDLzwp7KS/S/+aCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.77.tgz",
+      "integrity": "sha512-S1KtnP1+nWs2RApzNkdNf8X4trTLrHaY7FivV61ZRaL8NvuGOkSkKa+gWN2iedIGFEDz6gecpl/JAUSewwFXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.77.tgz",
+      "integrity": "sha512-A4YIKFYUwDtrSzCtdCAO5DYmRqlhCVKHdpq0+dBGPnIEhOQDFkPBTfoTAjO3pjlEnorlfKmNMOH21sKQg2esGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.77.tgz",
+      "integrity": "sha512-Lt6Sef5l0+5O1cSZ8ysO0JI+x+rSrqZyXs5f7+kVkCAOVq8X5WTcDVbvWvEs2aRhrWTp5y25Jf2Bn+3IcNHOuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.77.tgz",
+      "integrity": "sha512-NiNFvC+D+omVeJ3IjYlIbyt/igONSABVe9z0ZZph29epHgZYu4eHwV9osfpRt1BGGOAM8LkFrHk4LBdn2EDymA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.77.tgz",
+      "integrity": "sha512-fP6l0hZiWykyjvpZTS3sI46iib8QEflbPakNoUijtwyxRuOPTTBfzAWZUz5z2vKpJJ/8r305wnZeZ8lhsBHY5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@napi-rs/canvas": "^0.1.77",
     "@tailwindcss/postcss": "^4.1.11",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { classNames, todayISO } from "./utils";
 import { T_PRIMARY } from "./styles/tokens";
 import type { Mushroom, Zone, Spot } from "./types";
 import { MUSHROOMS } from "./data/mushrooms";
-import { getStaticMapUrl } from "./services/openstreetmap";
+import { getStaticMapUrl } from "./services/staticMap";
 import LandingScene from "./scenes/LandingScene";
 import MapScene from "./scenes/MapScene";
 import ZoneScene from "./scenes/ZoneScene";
@@ -148,10 +148,10 @@ function AppContent() {
               element={
                 <ZoneScene
                   zone={selectedZone}
-                  onAdd={() => {
+                  onAdd={async () => {
                     const today = todayISO();
                     const cover = selectedZone?.coords
-                      ? getStaticMapUrl(
+                      ? await getStaticMapUrl(
                           selectedZone.coords[0],
                           selectedZone.coords[1],
                           400,

--- a/src/services/openstreetmap.test.ts
+++ b/src/services/openstreetmap.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 vi.mock('maplibre-gl', () => ({}));
-import { reverseGeocode, getStaticMapUrl } from './openstreetmap';
+import { reverseGeocode } from './openstreetmap';
+import { getStaticMapUrl } from './staticMap';
+import { createCanvas, loadImage } from '@napi-rs/canvas';
 
 describe('reverseGeocode', () => {
   it('returns nearest place name', async () => {
@@ -24,8 +26,29 @@ describe('reverseGeocode', () => {
 });
 
 describe('getStaticMapUrl', () => {
-  it('builds a Carto tile URL keeping map style', () => {
-    const url = getStaticMapUrl(48.8566, 2.3522, 400, 200, 13);
-    expect(url).toMatch(/^https:\/\/[abcd]\.basemaps\.cartocdn\.com\/light_all\/13\/4150\/2818@2x\.png$/);
+  it('centers image on provided coordinates', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      const parts = url.split('/');
+      const x = parseInt(parts[parts.length - 2], 10);
+      const y = parseInt(parts[parts.length - 1].replace('.png', ''), 10);
+      const canvas = createCanvas(256, 256);
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = `rgb(${x % 256},${y % 256},0)`;
+      ctx.fillRect(0, 0, 256, 256);
+      const buf = canvas.toBuffer('image/png');
+      return {
+        ok: true,
+        arrayBuffer: async () => buf,
+      } as any;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const url = await getStaticMapUrl(0, 0, 512, 512, 2);
+    const img = await loadImage(Buffer.from(url.split(',')[1], 'base64'));
+    const c = createCanvas(512, 512);
+    const ctx = c.getContext('2d');
+    ctx.drawImage(img, 0, 0);
+    const data = ctx.getImageData(256, 256, 1, 1).data;
+    expect([data[0], data[1]]).toEqual([2, 2]);
+    vi.unstubAllGlobals();
   });
 });

--- a/src/services/staticMap.ts
+++ b/src/services/staticMap.ts
@@ -1,0 +1,118 @@
+export async function getStaticMapUrl(
+  lat: number,
+  lng: number,
+  width = 400,
+  height = 160,
+  zoom = 13
+): Promise<string> {
+  const xT = ((lng + 180) / 360) * Math.pow(2, zoom);
+  const yT =
+    ((1 -
+      Math.log(
+        Math.tan((lat * Math.PI) / 180) +
+          1 / Math.cos((lat * Math.PI) / 180)
+      ) /
+        Math.PI) /
+      2) *
+    Math.pow(2, zoom);
+  const xOffset = (xT - Math.floor(xT)) * 256;
+  const yOffset = (yT - Math.floor(yT)) * 256;
+
+  const leftTiles = Math.max(0, Math.ceil((width / 2 - xOffset) / 256));
+  const rightTiles = Math.max(
+    0,
+    Math.ceil((width / 2 - (256 - xOffset)) / 256)
+  );
+  const topTiles = Math.max(0, Math.ceil((height / 2 - yOffset) / 256));
+  const bottomTiles = Math.max(
+    0,
+    Math.ceil((height / 2 - (256 - yOffset)) / 256)
+  );
+
+  const startX = Math.floor(xT) - leftTiles;
+  const startY = Math.floor(yT) - topTiles;
+  const endX = Math.floor(xT) + rightTiles;
+  const endY = Math.floor(yT) + bottomTiles;
+
+  const tilesX = endX - startX + 1;
+  const tilesY = endY - startY + 1;
+
+  const canvas = await createCanvas(tilesX * 256, tilesY * 256);
+  const ctx = canvas.getContext('2d');
+
+  for (let ty = startY; ty <= endY; ty++) {
+    for (let tx = startX; tx <= endX; tx++) {
+      const sub = ['a', 'b', 'c', 'd'][Math.floor(Math.random() * 4)];
+      const url = `https://${sub}.basemaps.cartocdn.com/light_all/${zoom}/${tx}/${ty}.png`;
+      const img = await loadTile(url);
+      ctx.drawImage(img, (tx - startX) * 256, (ty - startY) * 256);
+    }
+  }
+
+  const centerX = (xT - startX) * 256;
+  const centerY = (yT - startY) * 256;
+  const cropX = Math.round(centerX - width / 2);
+  const cropY = Math.round(centerY - height / 2);
+
+  const outCanvas = await createCanvas(width, height);
+  const outCtx = outCanvas.getContext('2d');
+  outCtx.putImageData(ctx.getImageData(cropX, cropY, width, height), 0, 0);
+
+  return canvasToDataURL(outCanvas);
+}
+
+async function loadTile(url: string): Promise<any> {
+  const res = await fetch(url);
+  const arr = await res.arrayBuffer();
+  if (
+    typeof window !== 'undefined' &&
+    typeof Image !== 'undefined' &&
+    typeof URL !== 'undefined' &&
+    typeof URL.createObjectURL === 'function'
+  ) {
+    return loadImageBrowser(arr);
+  } else {
+    const { loadImage } = await import('@napi-rs/canvas');
+    return loadImage(Buffer.from(arr));
+  }
+}
+
+async function createCanvas(width: number, height: number): Promise<any> {
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas') as any;
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext?.('2d');
+    if (ctx) return canvas;
+  }
+  const { createCanvas } = await import('@napi-rs/canvas');
+  return createCanvas(width, height);
+}
+
+function canvasToDataURL(canvas: any): string {
+  if (typeof canvas.toDataURL === 'function') {
+    return canvas.toDataURL();
+  }
+  if (typeof canvas.toBuffer === 'function') {
+    const buf = canvas.toBuffer('image/png');
+    return `data:image/png;base64,${buf.toString('base64')}`;
+  }
+  throw new Error('Unsupported canvas object');
+}
+
+function loadImageBrowser(arr: ArrayBuffer): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const blob = new Blob([arr], { type: 'image/png' });
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = (e) => {
+      URL.revokeObjectURL(url);
+      reject(e);
+    };
+    img.src = url;
+  });
+}


### PR DESCRIPTION
## Summary
- build new static map service stitching Carto tiles into a cropped canvas and returning a data URL
- use the new static map generator in app flows and spot list
- add unit test confirming static maps center on requested coordinates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca0578bf083299eda011feb9a1620