### PR TITLE
Refine responsive grid breakpoints

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -87,5 +87,5 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
 
 @layer utilities {
   .container { @apply max-w-screen-xl mx-auto px-4 md:px-6; }
-    .grid-responsive { @apply grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4; }
+    .grid-responsive { @apply grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4; }
   }


### PR DESCRIPTION
## Summary
- tune grid-responsive utility to show 1/2/3/4 cards at default/sm/md/lg

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca01cb0f08329a0951d30a8f35985