### PR TITLE
refactor: centralize media query logic

### DIFF
--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export default function useMediaQuery(query: string) {
+  const [matches, setMatches] = React.useState(() => window.matchMedia(query).matches);
+  React.useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+  return matches;
+}

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -4,17 +4,7 @@ import MapCard from "@/components/history/MapCard";
 import InsightsCard from "@/components/history/InsightsCard";
 import EditHarvestModal from "@/components/harvest/EditHarvestModal";
 import { TimelineEvent } from "@/components/history/Timeline";
-
-function useMediaQuery(query: string) {
-  const [matches, setMatches] = React.useState(() => window.matchMedia(query).matches);
-  React.useEffect(() => {
-    const mql = window.matchMedia(query);
-    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
-    mql.addEventListener("change", handler);
-    return () => mql.removeEventListener("change", handler);
-  }, [query]);
-  return matches;
-}
+import useMediaQuery from "@/hooks/useMediaQuery";
 
 export default function History() {
   const events: TimelineEvent[] = [


### PR DESCRIPTION
## Summary
- extract reusable `useMediaQuery` hook
- use `useMediaQuery` in spot history view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9e10f12483298f5db51ee34c63a2