### PR TITLE
Use i18n translations in history and harvest screens

### DIFF
--- a/src/components/harvest/EditHarvestModal.tsx
+++ b/src/components/harvest/EditHarvestModal.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
+import { useT } from "@/i18n";
 
 type Harvest = {
   id?: string;
@@ -26,6 +27,7 @@ export function EditHarvestModal({
   onDelete?: () => void;
   initial?: Harvest;
 }) {
+  const { t } = useT();
   const [date, setDate] = useState(initial?.date || "");
   const [rating, setRating] = useState(initial?.rating ?? 0);
   const [comment, setComment] = useState(initial?.comment || "");
@@ -51,7 +53,7 @@ export function EditHarvestModal({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const err: { date?: string } = {};
-    if (!date) err.date = "Requis";
+    if (!date) err.date = t("Requis");
     setErrors(err);
     if (Object.keys(err).length) return;
     setLoading(true);
@@ -67,24 +69,24 @@ export function EditHarvestModal({
   };
 
   const removePhoto = (url: string) => {
-    if (confirm("Supprimer cette photo ?")) setPhotos(p => p.filter(u => u !== url));
+    if (confirm(t("Supprimer cette photo ?"))) setPhotos(p => p.filter(u => u !== url));
   };
 
   return (
     <Modal open={open} onClose={onClose}>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <h2 className="text-lg font-semibold">Modifier la cueillette</h2>
+        <h2 className="text-lg font-semibold">{t("Modifier la cueillette")}</h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <div className="space-y-2">
             <label htmlFor="date" className="text-sm">
-              Date
+              {t("Date")}
             </label>
             <Input id="date" type="date" value={date} onChange={e => setDate(e.target.value)} />
             {errors.date && <p className="text-xs text-danger">{errors.date}</p>}
           </div>
           <div className="space-y-2">
             <label htmlFor="rating" className="text-sm">
-              Note
+              {t("Note")}
             </label>
             <Select id="rating" value={String(rating)} onChange={e => setRating(parseInt(e.target.value, 10))}>
               {[0, 1, 2, 3, 4, 5].map(n => (
@@ -96,7 +98,7 @@ export function EditHarvestModal({
           </div>
           <div className="space-y-2 lg:col-span-2">
             <label htmlFor="comment" className="text-sm">
-              Commentaire
+              {t("Commentaire")}
             </label>
             <textarea
               id="comment"
@@ -106,7 +108,7 @@ export function EditHarvestModal({
             />
           </div>
           <div className="space-y-2 lg:col-span-2">
-            <label className="text-sm">Galerie</label>
+            <label className="text-sm">{t("Galerie")}</label>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
               {photos.map(url => (
                 <div key={url} className="relative aspect-square">
@@ -117,7 +119,7 @@ export function EditHarvestModal({
                     variant="destructive"
                     className="absolute top-1 right-1 h-6 w-6 p-0"
                     onClick={() => removePhoto(url)}
-                    aria-label="Supprimer"
+                    aria-label={t("Supprimer")}
                   >
                     <Trash2 className="w-4 h-4" />
                   </Button>
@@ -137,7 +139,7 @@ export function EditHarvestModal({
               variant="secondary"
               onClick={() => document.getElementById("file")?.click()}
             >
-              Importer des photos
+              {t("Importer des photos")}
             </Button>
           </div>
         </div>
@@ -149,18 +151,18 @@ export function EditHarvestModal({
               className="text-danger border border-danger hover:bg-danger/10"
               onClick={onDelete}
             >
-              Supprimer
+              {t("Supprimer")}
             </Button>
           )}
           <div className="ml-auto flex gap-2 w-full sm:w-auto">
             <Button type="button" variant="secondary" onClick={onClose} className="flex-1 sm:flex-none">
-              Annuler
+              {t("Annuler")}
             </Button>
             <Button type="submit" disabled={loading} className="flex-1 sm:flex-none">
               {loading && (
                 <span className="mr-2 inline-block w-4 h-4 rounded-full border-2 border-border border-t-transparent animate-spin" />
               )}
-              Enregistrer
+              {t("Enregistrer")}
             </Button>
           </div>
         </div>

--- a/src/components/history/InsightsCard.tsx
+++ b/src/components/history/InsightsCard.tsx
@@ -5,12 +5,7 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tool
 import ChartSkeleton from "./ChartSkeleton";
 import { Timeline, TimelineEvent } from "./Timeline";
 import TimelineSkeleton from "./TimelineSkeleton";
-
-const tabs = [
-  { id: "history", label: "Historique" },
-  { id: "forecast", label: "Prévisions locales" },
-  { id: "visits", label: "Visites" },
-];
+import { useT } from "@/i18n";
 
 function formatDate(str: string) {
   const d = new Date(str);
@@ -20,6 +15,12 @@ function formatDate(str: string) {
 }
 
 export function InsightsCard({ events, onSelect }: { events: TimelineEvent[]; onSelect: (id: string) => void }) {
+  const { t } = useT();
+  const tabs = [
+    { id: "history", label: t("Historique") },
+    { id: "forecast", label: t("Prévisions locales") },
+    { id: "visits", label: t("Visites") },
+  ];
   const [active, setActive] = useState("history");
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<{ date: string; value: number }[]>([]);
@@ -47,7 +48,7 @@ export function InsightsCard({ events, onSelect }: { events: TimelineEvent[]; on
   return (
     <Card className="p-4 lg:p-6 flex flex-col">
       <CardHeader className="p-0 mb-4 border-none">
-        <CardTitle>Insights</CardTitle>
+        <CardTitle>{t("Insights")}</CardTitle>
       </CardHeader>
       <CardContent className="p-0 flex-1 flex flex-col">
         <Tabs tabs={tabs} active={active} onChange={setActive} />

--- a/src/components/history/MapCard.tsx
+++ b/src/components/history/MapCard.tsx
@@ -2,8 +2,10 @@ import React, { useEffect, useRef } from "react";
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
 import { loadMap } from "@/services/openstreetmap";
 import type { StyleSpecification } from "maplibre-gl";
+import { useT } from "@/i18n";
 
 export function MapCard({ center }: { center: [number, number] }) {
+  const { t } = useT();
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<any>(null);
   useEffect(() => {
@@ -17,7 +19,7 @@ export function MapCard({ center }: { center: [number, number] }) {
             type: "raster",
             tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
             tileSize: 256,
-            attribution: "© OpenStreetMap contributors | MapLibre",
+            attribution: t("© OpenStreetMap contributors | MapLibre"),
           },
         },
         layers: [
@@ -45,8 +47,8 @@ export function MapCard({ center }: { center: [number, number] }) {
   return (
     <Card className="p-4 lg:p-6">
       <CardHeader className="p-0 mb-4 border-none">
-        <CardTitle>Carte du coin</CardTitle>
-        <p className="text-sm text-foreground/70">La carte affiche l’historique complet avec détails.</p>
+        <CardTitle>{t("Carte du coin")}</CardTitle>
+        <p className="text-sm text-foreground/70">{t("La carte affiche l’historique complet avec détails.")}</p>
       </CardHeader>
       <CardContent className="p-0">
         <div className="relative w-full rounded-md border border-border overflow-hidden aspect-video">
@@ -54,7 +56,7 @@ export function MapCard({ center }: { center: [number, number] }) {
         </div>
       </CardContent>
       <CardFooter className="pt-2 flex justify-end">
-        <p className="text-xs text-foreground/50">© OpenStreetMap contributors | MapLibre</p>
+        <p className="text-xs text-foreground/50">{t("© OpenStreetMap contributors | MapLibre")}</p>
       </CardFooter>
     </Card>
   );

--- a/src/i18n/common.ts
+++ b/src/i18n/common.ts
@@ -176,4 +176,14 @@ export default {
   "⬈ amélioration": { fr: "⬈ amélioration", en: "⬈ improving" },
   "⬊ en baisse": { fr: "⬊ en baisse", en: "⬊ decreasing" },
   "→ stable": { fr: "→ stable", en: "→ stable" },
+  "Historique": { fr: "Historique", en: "History" },
+  "Prévisions locales": { fr: "Prévisions locales", en: "Local forecasts" },
+  "Insights": { fr: "Insights", en: "Insights" },
+  "Visite": { fr: "Visite", en: "Visit" },
+  "Requis": { fr: "Requis", en: "Required" },
+  "Supprimer cette photo ?": { fr: "Supprimer cette photo ?", en: "Delete this photo?" },
+  "© OpenStreetMap contributors | MapLibre": {
+    fr: "© OpenStreetMap contributors | MapLibre",
+    en: "© OpenStreetMap contributors | MapLibre",
+  },
 };

--- a/src/routes/spots/History.test.tsx
+++ b/src/routes/spots/History.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import History from "./History";
+import { AppProvider } from "@/context/AppContext";
 
 function setScreenWidth(width: number) {
   Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
@@ -50,19 +51,31 @@ describe("History page", () => {
 
   it("renders bottom CTA on mobile", () => {
     setScreenWidth(500);
-    render(<History />);
+    render(
+      <AppProvider>
+        <History />
+      </AppProvider>
+    );
     expect(screen.getAllByText("Ajouter une cueillette").length).toBe(2);
   });
 
   it("hides bottom CTA on desktop", () => {
     setScreenWidth(1200);
-    render(<History />);
+    render(
+      <AppProvider>
+        <History />
+      </AppProvider>
+    );
     expect(screen.getAllByText("Ajouter une cueillette").length).toBe(1);
   });
 
   it("opens and closes modal", () => {
     setScreenWidth(1200);
-    render(<History />);
+    render(
+      <AppProvider>
+        <History />
+      </AppProvider>
+    );
     fireEvent.click(screen.getByText("Ajouter une cueillette"));
     expect(screen.getByText("Modifier la cueillette")).toBeInTheDocument();
     fireEvent.keyDown(window, { key: "Escape" });
@@ -71,7 +84,11 @@ describe("History page", () => {
 
   it("validates form fields", () => {
     setScreenWidth(1200);
-    render(<History />);
+    render(
+      <AppProvider>
+        <History />
+      </AppProvider>
+    );
     fireEvent.click(screen.getByText("Ajouter une cueillette"));
     const save = screen.getByText("Enregistrer");
     fireEvent.click(save);
@@ -80,7 +97,11 @@ describe("History page", () => {
 
   it("opens modal via keyboard on timeline", async () => {
     setScreenWidth(1200);
-    render(<History />);
+    render(
+      <AppProvider>
+        <History />
+      </AppProvider>
+    );
     const rowText = await screen.findByText("01/09/2024");
     const row = rowText.closest("button") as HTMLButtonElement;
     row.focus();

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -4,6 +4,7 @@ import MapCard from "@/components/history/MapCard";
 import InsightsCard from "@/components/history/InsightsCard";
 import EditHarvestModal from "@/components/harvest/EditHarvestModal";
 import { TimelineEvent } from "@/components/history/Timeline";
+import { useT } from "@/i18n";
 
 function useMediaQuery(query: string) {
   const [matches, setMatches] = React.useState(() => window.matchMedia(query).matches);
@@ -17,9 +18,10 @@ function useMediaQuery(query: string) {
 }
 
 export default function History() {
+  const { t } = useT();
   const events: TimelineEvent[] = [
-    { id: "1", date: "01/09/2024", rating: 3, label: "Création" },
-    { id: "2", date: "10/09/2024", rating: 4, label: "Visite" },
+    { id: "1", date: "01/09/2024", rating: 3, label: t("Création") },
+    { id: "2", date: "10/09/2024", rating: 4, label: t("Visite") },
   ];
   const [editing, setEditing] = useState<TimelineEvent | null>(null);
   const isMobile = useMediaQuery("(max-width: 1023px)");
@@ -27,8 +29,8 @@ export default function History() {
   return (
     <section className="p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Historique du coin</h1>
-        <Button onClick={() => setEditing({ id: "", date: "", rating: 0, label: "" })}>Ajouter une cueillette</Button>
+        <h1 className="text-xl font-semibold">{t("Historique du coin")}</h1>
+        <Button onClick={() => setEditing({ id: "", date: "", rating: 0, label: "" })}>{t("Ajouter une cueillette")}</Button>
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <MapCard center={[48.8566, 2.3522]} />
@@ -37,7 +39,7 @@ export default function History() {
       {isMobile && (
         <div>
           <Button className="w-full" onClick={() => setEditing({ id: "", date: "", rating: 0, label: "" })}>
-            Ajouter une cueillette
+            {t("Ajouter une cueillette")}
           </Button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- replace hardcoded labels in history, map, insights, and edit-harvest components with i18n `t()` calls
- add missing translation keys for history and map strings
- wrap history tests with app provider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9db9711483299884332243246867