### PR TITLE
Exclude @napi-rs/canvas from Vite optimization

### DIFF
--- a/src/services/staticMap.ts
+++ b/src/services/staticMap.ts
@@ -72,7 +72,7 @@ async function loadTile(url: string): Promise<any> {
   ) {
     return loadImageBrowser(arr);
   } else {
-    const { loadImage } = await import('@napi-rs/canvas');
+    const { loadImage } = await import(/* @vite-ignore */ '@napi-rs/canvas');
     return loadImage(Buffer.from(arr));
   }
 }
@@ -85,7 +85,7 @@ async function createCanvas(width: number, height: number): Promise<any> {
     const ctx = canvas.getContext?.('2d');
     if (ctx) return canvas;
   }
-  const { createCanvas } = await import('@napi-rs/canvas');
+  const { createCanvas } = await import(/* @vite-ignore */ '@napi-rs/canvas');
   return createCanvas(width, height);
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
+  optimizeDeps: {
+    exclude: ['@napi-rs/canvas'],
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- ignore `@napi-rs/canvas` in dynamic imports
- prevent Vite from optimizing `@napi-rs/canvas`

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689ca6da5ff48329b9bdac238156ba6c