### PR TITLE
fix: ensure four-column layout for mushrooms

### DIFF
--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -105,8 +105,8 @@ describe("MushroomsIndex", () => {
     const classes = grid.className;
     expect(classes).toContain("grid-cols-1");
     expect(classes).toContain("sm:grid-cols-2");
-    expect(classes).toContain("lg:grid-cols-3");
-    expect(classes).toContain("xl:grid-cols-4");
+    expect(classes).toContain("md:grid-cols-3");
+    expect(classes).toContain("lg:grid-cols-4");
   });
 
   it("shows loading and empty states", async () => {

--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -118,7 +118,7 @@ export default function MushroomsIndex() {
   if (loading) {
     return (
       <div className="container px-4 py-4">
-        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 [grid-auto-rows:1fr]">
           {Array.from({ length: 8 }).map((_, i) => (
             <MushroomCardSkeleton key={i} />
           ))}
@@ -189,7 +189,7 @@ export default function MushroomsIndex() {
       />
 
       {filtered.length === 0 ? (
-        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 [grid-auto-rows:1fr]">
           <div className="flex flex-col items-center justify-center rounded-lg border border-border p-6 text-center">
             <p className="mb-2 text-foreground/70">Aucun résultat</p>
             <button
@@ -208,7 +208,7 @@ export default function MushroomsIndex() {
       ) : (
         <div
           data-testid="mushrooms-grid"
-          className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]"
+          className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 [grid-auto-rows:1fr]"
         >
           {displayed.map((m) => (
             <MushroomCard key={m.id} mushroom={m} onSelect={() => setDetails(m)} />


### PR DESCRIPTION
## Summary
- ensure mushroom list uses up to four columns on large screens
- adjust tests for new responsive grid layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb204de1c8329955ad7bcdcf6d56a