### PR TITLE
feat: use clicked coordinates for custom zone

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -98,34 +98,20 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
         }
       }
 
-      // Find nearest demo zone to the tapped coordinates
-      let nearest: Zone | null = null;
-      let minDist = Infinity;
-      for (const z of DEMO_ZONES) {
-        const [zLat, zLng] = z.coords;
-        const dist = Math.hypot(lat - zLat, lng - zLng);
-        if (dist < minDist) {
-          minDist = dist;
-          nearest = z;
-        }
-      }
-      if (nearest) {
-        const speciesLines = Object.entries(nearest.species)
-          .map(([id, sc]) => {
-            const name =
-              MUSHROOMS.find(m => m.id === id)?.name.split(" ")[0] || id;
-            return `${name} ${sc}%`;
-          })
-          .join("\n");
-
-        const placeName = await reverseGeocode(lat, lng);
-        const zone = placeName ? { ...nearest, name: placeName } : nearest;
-        const msg = `${zone.name}\n${zone.score}% ${zone.trend}\n${speciesLines}`;
-        setToasts(curr => [{ id, text: msg, zone }, ...curr].slice(0, 3));
-        setTimeout(() => {
-          setToasts(curr => curr.filter(t => t.id !== id));
-        }, 45000);
-      }
+      // Create a new zone based on the tapped coordinates
+      const placeName = await reverseGeocode(lat, lng);
+      const zone: Zone = {
+        id: `zone-${id}`,
+        name: placeName || "Zone",
+        score: 0,
+        species: {},
+        trend: "",
+        coords: [lat, lng],
+      };
+      setToasts(curr => [{ id, text: zone.name, zone }, ...curr].slice(0, 3));
+      setTimeout(() => {
+        setToasts(curr => curr.filter(t => t.id !== id));
+      }, 45000);
     },
     []
   );

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -5,7 +5,6 @@ import { vi, describe, it, expect } from 'vitest';
 
 import MapScene from '../MapScene';
 import { AppProvider } from '@/context/AppContext';
-import { DEMO_ZONES } from '../../data/zones';
 
 // Hoist mocks for framer-motion
 const { motionSection } = vi.hoisted(() => ({
@@ -66,7 +65,7 @@ describe('MapScene', () => {
     fireEvent.click(toast);
 
     expect(onZone).toHaveBeenCalledWith(
-      expect.objectContaining({ id: DEMO_ZONES[1].id, name: 'Testville' })
+      expect.objectContaining({ name: 'Testville', coords: [45.7, 5.9] })
     );
   });
 });


### PR DESCRIPTION
## Summary
- create zone directly from clicked coordinates
- show chosen location name in toast
- update map scene test for new zone behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb474b4008329aef22f263ae85349