### PR TITLE
Move map toasts to bottom of map card

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -230,7 +230,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
           </div>
         </div>
         {toasts.length > 0 && (
-          <div className="absolute left-3 top-3 flex flex-col space-y-2">
+          <div className="absolute left-3 bottom-3 flex flex-col space-y-2">
             {toasts.map(toast => (
               <Toast
                 key={toast.id}


### PR DESCRIPTION
## Summary
- place map tap toasts near bottom-left of map card to keep them fully visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb534240c83298f3343998594b7bd