### PR TITLE
Handle adding spots from mushroom details

### DIFF
--- a/src/components/mushrooms/MushroomDetails.tsx
+++ b/src/components/mushrooms/MushroomDetails.tsx
@@ -3,6 +3,9 @@ import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import type { Mushroom } from "@/types";
+import { useAppContext } from "@/context/AppContext";
+import { todayISO } from "@/utils";
+import { useT } from "@/i18n";
 
 interface Props {
   mushroom: Mushroom | null;
@@ -11,7 +14,31 @@ interface Props {
 }
 
 export default function MushroomDetails({ mushroom, open, onClose }: Props) {
+  const { dispatch } = useAppContext();
+  const { t } = useT();
+
   if (!mushroom) return null;
+
+  const addSpot = () => {
+    const today = todayISO();
+    dispatch({
+      type: "addSpot",
+      spot: {
+        id: Date.now(),
+        cover: mushroom.photo,
+        photos: [mushroom.photo],
+        name: mushroom.name,
+        species: [mushroom.id],
+        rating: 5,
+        last: today,
+        history: [
+          { date: today, rating: 5, note: t("Créé"), photos: [mushroom.photo] },
+        ],
+      },
+    });
+    onClose();
+  };
+
   return (
     <Modal open={open} onClose={onClose}>
       <div className="md:ml-auto md:h-full md:max-w-md md:w-full md:rounded-none overflow-y-auto">
@@ -27,7 +54,7 @@ export default function MushroomDetails({ mushroom, open, onClose }: Props) {
           <p className="text-sm text-foreground/80">{mushroom.description}</p>
           <div className="flex gap-2">
             <Button onClick={onClose}>Voir sur la carte</Button>
-            <Button variant="secondary" onClick={onClose}>Ajouter à mes coins</Button>
+            <Button variant="secondary" onClick={addSpot}>Ajouter à mes coins</Button>
           </div>
         </div>
       </div>

--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -5,6 +5,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import "@/index.css";
 
 import MushroomsIndex from "../index";
+import { AppProvider } from "@/context/AppContext";
 import type { Mushroom } from "@/types";
 
 const mushrooms: Mushroom[] = [
@@ -59,7 +60,11 @@ describe("MushroomsIndex", () => {
   });
 
   it("searches, filters and sorts", async () => {
-    render(<MushroomsIndex />);
+    render(
+      <AppProvider>
+        <MushroomsIndex />
+      </AppProvider>
+    );
     await waitFor(() => screen.getAllByText("Cèpe"));
     const search = screen.getByPlaceholderText("Rechercher") as HTMLInputElement;
     fireEvent.change(search, { target: { value: "moril" } });
@@ -79,7 +84,11 @@ describe("MushroomsIndex", () => {
   });
 
   it("card is focusable and activable via keyboard", async () => {
-    render(<MushroomsIndex />);
+    render(
+      <AppProvider>
+        <MushroomsIndex />
+      </AppProvider>
+    );
     await waitFor(() => screen.getByRole("link", { name: /Cèpe/ }));
     const card = screen.getByRole("link", { name: /Cèpe/ });
     card.focus();
@@ -90,7 +99,11 @@ describe("MushroomsIndex", () => {
   });
 
   it("activates card with Space key", async () => {
-    render(<MushroomsIndex />);
+    render(
+      <AppProvider>
+        <MushroomsIndex />
+      </AppProvider>
+    );
     await waitFor(() => screen.getByRole("link", { name: /Cèpe/ }));
     const card = screen.getByRole("link", { name: /Cèpe/ });
     card.focus();
@@ -99,7 +112,11 @@ describe("MushroomsIndex", () => {
   });
 
   it("renders responsive columns", async () => {
-    render(<MushroomsIndex />);
+    render(
+      <AppProvider>
+        <MushroomsIndex />
+      </AppProvider>
+    );
     await waitFor(() => screen.getByTestId("mushrooms-grid"));
     const grid = screen.getByTestId("mushrooms-grid");
     const classes = grid.className;
@@ -110,7 +127,11 @@ describe("MushroomsIndex", () => {
   });
 
   it("shows loading and empty states", async () => {
-    const { container } = render(<MushroomsIndex />);
+    const { container } = render(
+      <AppProvider>
+        <MushroomsIndex />
+      </AppProvider>
+    );
     expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
     await waitFor(() => screen.getByRole("link", { name: /Cèpe/ }));
     fireEvent.change(screen.getByPlaceholderText("Rechercher"), { target: { value: "xyz" } });

--- a/src/services/staticMap.ts
+++ b/src/services/staticMap.ts
@@ -82,8 +82,12 @@ async function createCanvas(width: number, height: number): Promise<any> {
     const canvas = document.createElement('canvas') as any;
     canvas.width = width;
     canvas.height = height;
-    const ctx = canvas.getContext?.('2d');
-    if (ctx) return canvas;
+    try {
+      const ctx = canvas.getContext('2d');
+      if (ctx) return canvas;
+    } catch {
+      // jsdom may not implement canvas, fall back to node canvas
+    }
   }
   const { createCanvas } = await import(/* @vite-ignore */ '@napi-rs/canvas');
   return createCanvas(width, height);


### PR DESCRIPTION
## Summary
- enable adding a spot from mushroom details modal
- avoid jsdom canvas errors with fallback in static map service
- wrap mushrooms index tests with AppProvider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb58cb3d08329b1f1ff6fe6b5e4f9