### PR TITLE
Enhance map toast notifications

### DIFF
--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -7,14 +7,17 @@ import MapScene from '../MapScene';
 import { AppProvider } from '@/context/AppContext';
 
 // Hoist mocks for framer-motion
-const { motionSection } = vi.hoisted(() => ({
+const { motionSection, motionButton } = vi.hoisted(() => ({
   motionSection: vi.fn((props: any) => <section {...props} />),
+  motionButton: vi.fn((props: any) => <button {...props} />),
 }));
 
 vi.mock('framer-motion', () => ({
   motion: {
     section: motionSection,
+    button: motionButton,
   },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
 }));
 
 let mapInstance: any;


### PR DESCRIPTION
## Summary
- Animate map toast cards and display demo mushroom stats
- Show a playful warning when clicking water areas
- Adjust MapScene tests to mock new framer-motion features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb720ba78832984113366d6ff3c5c