### PR TITLE
Adjust toast notification vertical offset

### DIFF
--- a/src/components/ui/Toaster.tsx
+++ b/src/components/ui/Toaster.tsx
@@ -22,9 +22,9 @@ type Position =
   | 'bottom-center';
 
 const POS: Record<Position, string> = {
-  'top-right': 'top-4 right-4 items-end',
-  'top-left': 'top-4 left-4 items-start',
-  'top-center': 'top-4 left-1/2 -translate-x-1/2 items-center',
+  'top-right': 'top-8 right-4 items-end',
+  'top-left': 'top-8 left-4 items-start',
+  'top-center': 'top-8 left-1/2 -translate-x-1/2 items-center',
   'bottom-right': 'bottom-4 right-4 items-end',
   'bottom-left': 'bottom-4 left-4 items-start',
   'bottom-center': 'bottom-4 left-1/2 -translate-x-1/2 items-center',


### PR DESCRIPTION
## Summary
- move top-aligned toast notifications slightly lower for improved spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cbe32d5548329ab3e3d6348e74f0e