### PR TITLE
feat: position map notifications below legend

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -244,7 +244,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
           </div>
         </div>
         {toasts.length > 0 && (
-          <div className="absolute left-3 top-3 flex flex-col space-y-2">
+          <div className="absolute left-3 top-24 sm:top-16 flex flex-col space-y-2">
             <AnimatePresence initial={false}>
               {toasts.map(toast => (
                 <Toast


### PR DESCRIPTION
## Summary
- ensure map scene notifications render below legend on all screens
- add responsive top spacing to toast stack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc411bb7083298f69f934a10e689a