### PR TITLE
Handle water clicks without place name

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -125,9 +125,9 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
         coords: [lat, lng],
       };
 
-      const lower = zone.name.toLowerCase();
       const waterWords = ["eau", "lac", "rivière", "river", "mer", "océan", "étang", "sea", "water"];
-      if (waterWords.some(w => lower.includes(w))) {
+      const lower = (placeName || "").toLowerCase();
+      if (!placeName || waterWords.some(w => lower.includes(w))) {
         setToasts(curr => [
           { id, text: "Pas de champignons ici 😄", zone },
           ...curr,

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -5,6 +5,7 @@ import { vi, describe, it, expect } from 'vitest';
 
 import MapScene from '../MapScene';
 import { AppProvider } from '@/context/AppContext';
+import { reverseGeocode } from '../../services/openstreetmap';
 
 // Hoist mocks for framer-motion
 const { motionSection, motionButton } = vi.hoisted(() => ({
@@ -70,5 +71,20 @@ describe('MapScene', () => {
     expect(onZone).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Testville', coords: [45.7, 5.9] })
     );
+  });
+
+  it('shows water message when place has no name', async () => {
+    (reverseGeocode as any).mockResolvedValueOnce(null);
+    render(
+      <AppProvider>
+        <MapScene onZone={() => {}} gpsFollow={false} setGpsFollow={() => {}} onBack={() => {}} />
+      </AppProvider>
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    mapInstance.handlers.click({ lngLat: { lat: 0, lng: 0 } });
+
+    const toast = await screen.findByRole('button', { name: /Pas de champignons ici/ });
+    expect(toast).toBeInTheDocument();
   });
 });

--- a/src/services/openstreetmap.test.ts
+++ b/src/services/openstreetmap.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from 'vitest';
 vi.mock('maplibre-gl', () => ({}));
 import { reverseGeocode } from './openstreetmap';


### PR DESCRIPTION
## Summary
- Handle clicks on map water areas by checking reverse geocode result before defaulting to demo zone
- Add regression test for water message when reverse geocoding returns null
- Run static map tests in Node environment to avoid canvas issues

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cfbd427488329878374af7727d29c