### PR TITLE
Use grid-responsive class for mushrooms grid

### DIFF
--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -120,10 +120,8 @@ describe("MushroomsIndex", () => {
     await waitFor(() => screen.getByTestId("mushrooms-grid"));
     const grid = screen.getByTestId("mushrooms-grid");
     const classes = grid.className;
-    expect(classes).toContain("grid-cols-1");
-    expect(classes).toContain("sm:grid-cols-2");
-    expect(classes).toContain("md:grid-cols-3");
-    expect(classes).toContain("lg:grid-cols-4");
+    expect(classes).toContain("grid-responsive");
+    expect(classes).toContain("w-full");
   });
 
   it("shows loading and empty states", async () => {

--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -208,7 +208,7 @@ export default function MushroomsIndex() {
       ) : (
         <div
           data-testid="mushrooms-grid"
-          className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 [grid-auto-rows:1fr]"
+          className="grid-responsive w-full"
         >
           {displayed.map((m) => (
             <MushroomCard key={m.id} mushroom={m} onSelect={() => setDetails(m)} />


### PR DESCRIPTION
## Summary
- replace responsive class chain with custom `grid-responsive` and `w-full` for mushrooms list
- update tests to look for `grid-responsive` class

## Testing
- `npm test`
- `npm run dev` *(fails: cannot verify visual layout in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_689cfda24cd48329ad60bc977ccc9ce0