### PR TITLE
chore: remove redundant container padding

### DIFF
--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -117,7 +117,7 @@ export default function MushroomsIndex() {
 
   if (loading) {
     return (
-      <div className="container px-4 py-4">
+      <div className="container py-4">
         <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 [grid-auto-rows:1fr]">
           {Array.from({ length: 8 }).map((_, i) => (
             <MushroomCardSkeleton key={i} />
@@ -129,7 +129,7 @@ export default function MushroomsIndex() {
 
   if (error) {
     return (
-      <div className="container px-4 py-4 space-y-4">
+      <div className="container py-4 space-y-4">
         <p className="text-foreground">Erreur de chargement.</p>
         <button
           className="underline text-foreground"
@@ -151,7 +151,7 @@ export default function MushroomsIndex() {
   }
 
   return (
-    <div className="container px-4 py-4 space-y-4">
+    <div className="container py-4 space-y-4">
       <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-4">
         <Input
           placeholder="Rechercher"

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -37,7 +37,7 @@ export default function SettingsIndex() {
   }, [active]);
 
   return (
-    <div className="container max-w-3xl mx-auto px-4 py-6 space-y-6">
+    <div className="container max-w-3xl mx-auto py-6 space-y-6">
       <header className="flex items-center gap-2">
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary
- remove extra `px-4` classes from container elements in mushrooms and settings routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d035ff6b4832992956c4f12b4d43d