### PR TITLE
Standardize mushrooms grid layout

### DIFF
--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -32,7 +32,7 @@ export default function MushroomCard({ mushroom, onSelect, disabled = false }: P
       aria-disabled={disabled}
       onKeyDown={handleKey}
       onClick={handleClick}
-      className={`group relative h-full flex flex-col rounded-lg border border-border bg-paper text-foreground shadow-sm transition hover:shadow-md focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:-translate-y-0.5 active:scale-[.99] ${disabled ? "pointer-events-none opacity-50" : ""}`}
+        className={`h-full flex flex-col group relative rounded-lg border border-border bg-paper text-foreground shadow-sm transition hover:shadow-md focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:-translate-y-0.5 active:scale-[.99] ${disabled ? "pointer-events-none opacity-50" : ""}`}
     >
       <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-[var(--surface-2)]">
         <img

--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -121,12 +121,13 @@ describe("MushroomsIndex", () => {
     const grid = screen.getByTestId("mushrooms-grid");
     const classes = grid.className;
     expect(classes).toContain("grid");
-    expect(classes).toContain("w-full");
-    expect(classes).toContain("gap-3");
+    expect(classes).not.toContain("w-full");
+    expect(classes).toContain("gap-6");
     expect(classes).toContain("grid-cols-1");
     expect(classes).toContain("sm:grid-cols-2");
-    expect(classes).toContain("md:grid-cols-3");
-    expect(classes).toContain("lg:grid-cols-4");
+    expect(classes).toContain("lg:grid-cols-3");
+    expect(classes).toContain("xl:grid-cols-4");
+    expect(classes).toContain("[grid-auto-rows:1fr]");
   });
 
   it("shows loading and empty states", async () => {

--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -117,7 +117,7 @@ export default function MushroomsIndex() {
 
   if (loading) {
     return (
-      <div className="container py-4">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 space-y-4">
         <div className="grid-responsive">
           {Array.from({ length: 8 }).map((_, i) => (
             <MushroomCardSkeleton key={i} />
@@ -129,7 +129,7 @@ export default function MushroomsIndex() {
 
   if (error) {
     return (
-      <div className="container py-4 space-y-4">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 space-y-4">
         <p className="text-foreground">Erreur de chargement.</p>
         <button
           className="underline text-foreground"
@@ -151,7 +151,7 @@ export default function MushroomsIndex() {
   }
 
   return (
-    <div className="container py-4 space-y-4">
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 space-y-4">
       <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-4">
         <Input
           placeholder="Rechercher"
@@ -208,7 +208,7 @@ export default function MushroomsIndex() {
       ) : (
         <div
           data-testid="mushrooms-grid"
-          className="grid w-full gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+          className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]"
         >
           {displayed.map((m) => (
             <MushroomCard key={m.id} mushroom={m} onSelect={() => setDetails(m)} />


### PR DESCRIPTION
## Summary
- align mushrooms page wrapper with app-wide container spacing
- rebuild mushroom card grid for 1/2/3/4 column breakpoints
- ensure `MushroomCard` roots use `h-full flex flex-col`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0b4078cc832992ed699feb194c89