### PR TITLE
chore: make cards flexible height

### DIFF
--- a/src/components/history/InsightsCard.tsx
+++ b/src/components/history/InsightsCard.tsx
@@ -46,7 +46,7 @@ export function InsightsCard({ events, onSelect }: { events: TimelineEvent[]; on
     : [];
 
   return (
-    <Card className="p-4 lg:p-6 flex flex-col">
+    <Card className="h-full p-4 lg:p-6 flex flex-col">
       <CardHeader className="p-0 mb-4 border-none">
         <CardTitle>{t("Insights")}</CardTitle>
       </CardHeader>

--- a/src/components/history/MapCard.tsx
+++ b/src/components/history/MapCard.tsx
@@ -46,14 +46,14 @@ export function MapCard({ center }: { center: [number, number] }) {
   }, [center]);
   const [lat, lng] = center;
   return (
-    <Card className="p-4 lg:p-6">
+    <Card className="h-full p-4 lg:p-6">
       <CardHeader className="p-0 mb-4 border-none">
         <CardTitle>{t("Carte du coin")}</CardTitle>
         <p className="text-sm text-foreground/70">{t("La carte affiche l'historique complet avec détails.")}</p>
       </CardHeader>
       <CardContent className="p-0">
         <div
-          className="relative w-full rounded-md border border-border overflow-hidden aspect-video"
+          className="relative rounded-md border border-border overflow-hidden aspect-video"
           role="img"
           aria-label={t("Carte de l'emplacement situé aux coordonnées latitude {lat}, longitude {lng}", { lat, lng })}
         >

--- a/src/components/mushrooms/MushroomCard.skeleton.tsx
+++ b/src/components/mushrooms/MushroomCard.skeleton.tsx
@@ -4,7 +4,7 @@ import Skeleton from "@/components/ui/skeleton";
 export default function MushroomCardSkeleton() {
   return (
     <div className="h-full flex flex-col rounded-lg border border-border bg-paper shadow-sm">
-      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-[var(--surface-2)]">
+        <div className="aspect-[4/3] overflow-hidden rounded-t-lg bg-[var(--surface-2)]">
         <Skeleton className="h-full w-full" />
       </div>
       <div className="flex grow flex-col gap-2 p-4">

--- a/src/components/mushrooms/MushroomCard.tsx
+++ b/src/components/mushrooms/MushroomCard.tsx
@@ -34,7 +34,7 @@ export default function MushroomCard({ mushroom, onSelect, disabled = false }: P
       onClick={handleClick}
       className={`group relative h-full flex flex-col rounded-lg border border-border bg-paper text-foreground shadow-sm transition hover:shadow-md focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:-translate-y-0.5 active:scale-[.99] ${disabled ? "pointer-events-none opacity-50" : ""}`}
     >
-      <div className="aspect-[4/3] w-full overflow-hidden rounded-t-lg bg-[var(--surface-2)]">
+        <div className="aspect-[4/3] overflow-hidden rounded-t-lg bg-[var(--surface-2)]">
         <img
           src={mushroom.photo}
           alt={mushroom.name}


### PR DESCRIPTION
## Summary
- remove width forcing from mushroom card image containers
- let map and insight cards stretch to fill grid rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0b519c00832992a09cd80f42401b