### PR TITLE
Replace grid-responsive utility with explicit Tailwind classes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -87,5 +87,4 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
 
 @layer utilities {
   .container { @apply max-w-screen-xl mx-auto px-4 md:px-6; }
-  .grid-responsive { @apply grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4; }
 }

--- a/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
+++ b/src/routes/mushrooms/__tests__/MushroomsIndex.test.tsx
@@ -121,12 +121,11 @@ describe("MushroomsIndex", () => {
     const grid = screen.getByTestId("mushrooms-grid");
     const classes = grid.className;
     expect(classes).toContain("grid");
-    expect(classes).toContain("w-full");
-    expect(classes).toContain("gap-3");
+    expect(classes).toContain("gap-6");
     expect(classes).toContain("grid-cols-1");
     expect(classes).toContain("sm:grid-cols-2");
-    expect(classes).toContain("md:grid-cols-3");
-    expect(classes).toContain("lg:grid-cols-4");
+    expect(classes).toContain("lg:grid-cols-3");
+    expect(classes).toContain("xl:grid-cols-4");
   });
 
   it("shows loading and empty states", async () => {

--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -118,7 +118,7 @@ export default function MushroomsIndex() {
   if (loading) {
     return (
       <div className="container py-4">
-        <div className="grid-responsive">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
           {Array.from({ length: 8 }).map((_, i) => (
             <MushroomCardSkeleton key={i} />
           ))}
@@ -189,7 +189,7 @@ export default function MushroomsIndex() {
       />
 
       {filtered.length === 0 ? (
-        <div className="grid-responsive">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
           <div className="flex flex-col items-center justify-center rounded-lg border border-border p-6 text-center">
             <p className="mb-2 text-foreground/70">Aucun résultat</p>
             <button
@@ -208,7 +208,7 @@ export default function MushroomsIndex() {
       ) : (
         <div
           data-testid="mushrooms-grid"
-          className="grid w-full gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+          className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]"
         >
           {displayed.map((m) => (
             <MushroomCard key={m.id} mushroom={m} onSelect={() => setDetails(m)} />

--- a/src/scenes/PickerScene.tsx
+++ b/src/scenes/PickerScene.tsx
@@ -20,78 +20,84 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
   const [valueFilter, setValueFilter] = useState("toutes");
   const { t } = useT();
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
-      <div className="grid md:grid-cols-4 gap-2 mb-3 items-center">
-        <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
-          <ChevronLeft className="w-5 h-5" />
-        </Button>
-        <Input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={t("Rechercher un champignon…")}
-          className={`bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
-        />
-        <Select
-          value={seasonFilter}
-          onChange={(e) => setSeasonFilter(e.target.value)}
-          className="bg-secondary border-secondary text-primary dark:bg-secondary dark:border-secondary dark:text-primary rounded-xl"
-        >
-          <option value="toutes">{t("Toutes saisons")}</option>
-          <option>{t("Printemps")}</option>
-          <option>{t("Été")}</option>
-          <option>{t("Automne")}</option>
-        </Select>
-        <Select
-          value={valueFilter}
-          onChange={(e) => setValueFilter(e.target.value)}
-          className="bg-secondary border-secondary text-primary dark:bg-secondary dark:border-secondary dark:text-primary rounded-xl"
-        >
-          <option value="toutes">{t("Toute valeur")}</option>
-          <option>{t("Excellente")}</option>
-          <option>{t("Bonne")}</option>
-          <option>{t("Moyenne")}</option>
-        </Select>
-      </div>
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+      <motion.section
+        initial={{ x: 20, opacity: 0 }}
+        animate={{ x: 0, opacity: 1 }}
+        exit={{ x: -20, opacity: 0 }}
+        className="p-3"
+      >
+        <div className="grid md:grid-cols-4 gap-2 mb-3 items-center">
+          <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
+            <ChevronLeft className="w-5 h-5" />
+          </Button>
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("Rechercher un champignon…")}
+            className={`bg-secondary border-secondary dark:bg-secondary dark:border-secondary ${T_PRIMARY}`}
+          />
+          <Select
+            value={seasonFilter}
+            onChange={(e) => setSeasonFilter(e.target.value)}
+            className="bg-secondary border-secondary text-primary dark:bg-secondary dark:border-secondary dark:text-primary rounded-xl"
+          >
+            <option value="toutes">{t("Toutes saisons")}</option>
+            <option>{t("Printemps")}</option>
+            <option>{t("Été")}</option>
+            <option>{t("Automne")}</option>
+          </Select>
+          <Select
+            value={valueFilter}
+            onChange={(e) => setValueFilter(e.target.value)}
+            className="bg-secondary border-secondary text-primary dark:bg-secondary dark:border-secondary dark:text-primary rounded-xl"
+          >
+            <option value="toutes">{t("Toute valeur")}</option>
+            <option>{t("Excellente")}</option>
+            <option>{t("Bonne")}</option>
+            <option>{t("Moyenne")}</option>
+          </Select>
+        </div>
 
-      <div className="grid-responsive">
-        {items.map((m) => (
-          <a
-            key={m.id}
-            href="#"
-            role="link"
-            onClick={(e) => {
-              e.preventDefault();
-              onPick(m);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
+          {items.map((m) => (
+            <a
+              key={m.id}
+              href="#"
+              role="link"
+              onClick={(e) => {
                 e.preventDefault();
                 onPick(m);
-              }
-            }}
-            className="block h-full no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-          >
-            <Card className="h-full flex flex-col">
-              <img
-                src={m.photo}
-                alt=""
-                className="w-full h-40 object-cover rounded-t-lg"
-                loading="lazy"
-              />
-              <CardContent className="p-3 flex flex-col flex-1">
-                <div className={`font-medium ${T_PRIMARY}`}>{m.name}</div>
-                <div className={`text-xs ${T_MUTED}`}>
-                  {t("Saison :")}{" "}
-                  {m.season}
-                </div>
-              </CardContent>
-            </Card>
-          </a>
-        ))}
-      </div>
-      <p className={`text-xs mt-2 ${T_SUBTLE}`}>
-        {t("Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.")}
-      </p>
-    </motion.section>
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  onPick(m);
+                }
+              }}
+              className="block h-full no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            >
+              <Card className="h-full flex flex-col">
+                <img
+                  src={m.photo}
+                  alt=""
+                  className="w-full h-40 object-cover rounded-t-lg"
+                  loading="lazy"
+                />
+                <CardContent className="p-3 flex flex-col flex-1">
+                  <div className={`font-medium ${T_PRIMARY}`}>{m.name}</div>
+                  <div className={`text-xs ${T_MUTED}`}>
+                    {t("Saison :")} {m.season}
+                  </div>
+                </CardContent>
+              </Card>
+            </a>
+          ))}
+        </div>
+        <p className={`text-xs mt-2 ${T_SUBTLE}`}>
+          {t("Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.")}
+        </p>
+      </motion.section>
+    </div>
   );
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,6 +2,12 @@
 module.exports = {
   darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  safelist: [
+    'grid-cols-1',
+    'sm:grid-cols-2',
+    'lg:grid-cols-3',
+    'xl:grid-cols-4',
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- remove custom `.grid-responsive` utility in favor of explicit Tailwind grid classes
- wrap `PickerScene` in a responsive container and apply explicit grid layout
- update mushrooms route and tests to use explicit grid classes
- add Tailwind safelist for responsive grid columns

## Testing
- `npm test`
- `npm run build` *(fails: Module "os" has been externalized for browser compatibility / Unexpected character '\u{7f}' in @napi-rs/canvas)*

------
https://chatgpt.com/codex/tasks/task_e_689d0b5c88e483298f004ae5ea40cc23