### PR TITLE
Add Tailwind safelist for grid utilities

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,6 +2,7 @@
 module.exports = {
   darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  safelist: ['grid-cols-1','sm:grid-cols-2','lg:grid-cols-3','xl:grid-cols-4'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- ensure responsive grid utilities are always included by adding a Tailwind `safelist`

## Testing
- `npm test`
- `npm run build` *(fails: "Module \"os\" has been externalized..." / `skia.linux-x64-gnu.node` unexpected character)*

------
https://chatgpt.com/codex/tasks/task_e_689d0b604a8c83299df2d77a7b7fa645