### PR TITLE
refactor: remove grid-responsive utility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -87,5 +87,4 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
 
 @layer utilities {
   .container { @apply max-w-screen-xl mx-auto px-4 md:px-6; }
-  .grid-responsive { @apply grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4; }
 }

--- a/src/routes/mushrooms/index.tsx
+++ b/src/routes/mushrooms/index.tsx
@@ -118,7 +118,7 @@ export default function MushroomsIndex() {
   if (loading) {
     return (
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 space-y-4">
-        <div className="grid-responsive">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
           {Array.from({ length: 8 }).map((_, i) => (
             <MushroomCardSkeleton key={i} />
           ))}
@@ -189,8 +189,8 @@ export default function MushroomsIndex() {
       />
 
       {filtered.length === 0 ? (
-        <div className="grid-responsive">
-          <div className="flex flex-col items-center justify-center rounded-lg border border-border p-6 text-center">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
+          <div className="flex flex-col items-center justify-center rounded-lg border border-border p-6 text-center h-full">
             <p className="mb-2 text-foreground/70">Aucun résultat</p>
             <button
               className="underline"

--- a/src/scenes/PickerScene.tsx
+++ b/src/scenes/PickerScene.tsx
@@ -20,8 +20,14 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
   const [valueFilter, setValueFilter] = useState("toutes");
   const { t } = useT();
   return (
-    <motion.section initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} exit={{ x: -20, opacity: 0 }} className="p-3">
-      <div className="grid md:grid-cols-4 gap-2 mb-3 items-center">
+    <motion.section
+      initial={{ x: 20, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: -20, opacity: 0 }}
+      className="p-3"
+    >
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid md:grid-cols-4 gap-2 mb-3 items-center">
         <Button variant="ghost" size="icon" onClick={onBack} className={BTN_GHOST_ICON} aria-label={t("Retour")}>
           <ChevronLeft className="w-5 h-5" />
         </Button>
@@ -51,47 +57,48 @@ export default function PickerScene({ items, search, setSearch, onPick, onBack }
           <option>{t("Bonne")}</option>
           <option>{t("Moyenne")}</option>
         </Select>
-      </div>
+        </div>
 
-      <div className="grid-responsive">
-        {items.map((m) => (
-          <a
-            key={m.id}
-            href="#"
-            role="link"
-            onClick={(e) => {
-              e.preventDefault();
-              onPick(m);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:1fr]">
+          {items.map((m) => (
+            <a
+              key={m.id}
+              href="#"
+              role="link"
+              onClick={(e) => {
                 e.preventDefault();
                 onPick(m);
-              }
-            }}
-            className="block h-full no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-          >
-            <Card className="h-full flex flex-col">
-              <img
-                src={m.photo}
-                alt=""
-                className="w-full h-40 object-cover rounded-t-lg"
-                loading="lazy"
-              />
-              <CardContent className="p-3 flex flex-col flex-1">
-                <div className={`font-medium ${T_PRIMARY}`}>{m.name}</div>
-                <div className={`text-xs ${T_MUTED}`}>
-                  {t("Saison :")}{" "}
-                  {m.season}
-                </div>
-              </CardContent>
-            </Card>
-          </a>
-        ))}
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  onPick(m);
+                }
+              }}
+              className="block h-full no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            >
+              <Card className="h-full flex flex-col">
+                <img
+                  src={m.photo}
+                  alt=""
+                  className="w-full h-40 object-cover rounded-t-lg"
+                  loading="lazy"
+                />
+                <CardContent className="p-3 flex flex-col flex-1">
+                  <div className={`font-medium ${T_PRIMARY}`}>{m.name}</div>
+                  <div className={`text-xs ${T_MUTED}`}>
+                    {t("Saison :")}{" "}
+                    {m.season}
+                  </div>
+                </CardContent>
+              </Card>
+            </a>
+          ))}
+        </div>
+        <p className={`text-xs mt-2 ${T_SUBTLE}`}>
+          {t("Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.")}
+        </p>
       </div>
-      <p className={`text-xs mt-2 ${T_SUBTLE}`}>
-        {t("Hors‑ligne : Cèpe, Girolle et Morille apparaissent par défaut.")}
-      </p>
     </motion.section>
   );
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,7 +2,12 @@
 module.exports = {
   darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
-  safelist: ["grid-cols-1", "sm:grid-cols-2", "lg:grid-cols-3", "xl:grid-cols-4"],
+  safelist: [
+    "grid-cols-1",
+    "sm:grid-cols-2",
+    "lg:grid-cols-3",
+    "xl:grid-cols-4",
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- drop custom `grid-responsive` class from index CSS
- apply explicit responsive grid utilities and container wrapper in PickerScene and mushrooms route
- safelist responsive grid classes in Tailwind config to prevent purge

## Testing
- `npm test`
- `npm run build` *(fails: Module "fs" has been externalized / skia .node unexpected character)*

------
https://chatgpt.com/codex/tasks/task_e_689d0efa74208329ba50b503bdcf3ffb