### PR TITLE
test: clear mocks after history tests

### DIFF
--- a/src/routes/spots/History.test.tsx
+++ b/src/routes/spots/History.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import History from "./History";
 import { AppProvider } from "@/context/AppContext";
 
@@ -35,6 +35,10 @@ describe("History page", () => {
         Tooltip: Mock
       };
     });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it("renders base layout", () => {


### PR DESCRIPTION
## Summary
- clear mocked modules after each History test to prevent leakage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f117d199c8329abf4d2cb67fc123e