### PR TITLE
refactor: extract Stars component

### DIFF
--- a/src/components/common/Stars.tsx
+++ b/src/components/common/Stars.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export function Stars({ value }: { value: number }) {
+  return (
+    <div className="flex text-gold" aria-label={`note ${value} sur 5`}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <span key={i} className={i < value ? "" : "text-foreground/20"}>
+          ★
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default Stars;

--- a/src/components/history/HarvestList.tsx
+++ b/src/components/history/HarvestList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import type { VisitHistory } from "@/types";
 import { useT } from "@/i18n";
+import { Stars } from "@/components/common/Stars";
 
 function formatDate(str: string) {
   const d = new Date(str);
@@ -10,18 +11,6 @@ function formatDate(str: string) {
   const mm = String(d.getMonth() + 1).padStart(2, "0");
   const yyyy = d.getFullYear();
   return `${dd}/${mm}/${yyyy}`;
-}
-
-function Stars({ value }: { value: number }) {
-  return (
-    <div className="flex text-gold" aria-label={`note ${value} sur 5`}>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <span key={i} className={i < value ? "" : "text-foreground/20"}>
-          ★
-        </span>
-      ))}
-    </div>
-  );
 }
 
 interface HarvestListProps {

--- a/src/components/history/LastHarvestCard.tsx
+++ b/src/components/history/LastHarvestCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { useT } from "@/i18n";
 import type { VisitHistory } from "@/types";
+import { Stars } from "@/components/common/Stars";
 
 function formatDate(str: string) {
   const d = new Date(str);
@@ -10,18 +11,6 @@ function formatDate(str: string) {
   const mm = String(d.getMonth() + 1).padStart(2, "0");
   const yyyy = d.getFullYear();
   return `${dd}/${mm}/${yyyy}`;
-}
-
-function Stars({ value }: { value: number }) {
-  return (
-    <div className="flex text-gold" aria-label={`note ${value} sur 5`}>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <span key={i} className={i < value ? "" : "text-foreground/20"}>
-          ★
-        </span>
-      ))}
-    </div>
-  );
 }
 
 export function LastHarvestCard({ harvest }: { harvest?: VisitHistory }) {


### PR DESCRIPTION
## Summary
- add shared Stars component for rating display
- use Stars in HarvestList and LastHarvestCard instead of local implementations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f117e8ca4832990de721521503947