### PR TITLE
feat: centralize date formatting

### DIFF
--- a/src/components/history/HarvestList.tsx
+++ b/src/components/history/HarvestList.tsx
@@ -2,15 +2,7 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import type { VisitHistory } from "@/types";
 import { useT } from "@/i18n";
-
-function formatDate(str: string) {
-  const d = new Date(str);
-  if (Number.isNaN(d.getTime())) return str;
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = d.getFullYear();
-  return `${dd}/${mm}/${yyyy}`;
-}
+import { formatDate } from "@/utils/dates";
 
 function Stars({ value }: { value: number }) {
   return (

--- a/src/components/history/LastHarvestCard.tsx
+++ b/src/components/history/LastHarvestCard.tsx
@@ -2,15 +2,7 @@ import React from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { useT } from "@/i18n";
 import type { VisitHistory } from "@/types";
-
-function formatDate(str: string) {
-  const d = new Date(str);
-  if (Number.isNaN(d.getTime())) return str;
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = d.getFullYear();
-  return `${dd}/${mm}/${yyyy}`;
-}
+import { formatDate } from "@/utils/dates";
 
 function Stars({ value }: { value: number }) {
   return (

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -18,14 +18,8 @@ import {
   CartesianGrid,
   Tooltip,
 } from "recharts";
+import { formatDate } from "@/utils/dates";
 
-function formatDate(str: string) {
-  const d = new Date(str);
-  if (Number.isNaN(d.getTime())) return str;
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  return `${dd}/${mm}`;
-}
 
 export default function History() {
   const { t } = useT();
@@ -87,9 +81,18 @@ export default function History() {
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
               <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="3 3" />
-              <XAxis dataKey="date" ticks={ticks} tickFormatter={formatDate} stroke="hsl(var(--foreground))" tick={{ fill: "hsl(var(--foreground))" }} />
+              <XAxis
+                dataKey="date"
+                ticks={ticks}
+                tickFormatter={(v) => formatDate(v).slice(0, 5)}
+                stroke="hsl(var(--foreground))"
+                tick={{ fill: "hsl(var(--foreground))" }}
+              />
               <YAxis domain={[0, 5]} stroke="hsl(var(--foreground))" tick={{ fill: "hsl(var(--foreground))" }} />
-              <Tooltip contentStyle={{ background: "hsl(var(--background))", border: "1px solid hsl(var(--border))", borderRadius: 4 }} labelFormatter={(v) => formatDate(v as string)} />
+              <Tooltip
+                contentStyle={{ background: "hsl(var(--background))", border: "1px solid hsl(var(--border))", borderRadius: 4 }}
+                labelFormatter={(v) => formatDate(v as string).slice(0, 5)}
+              />
               <Line type="monotone" dataKey="value" stroke="hsl(var(--forest-green))" strokeWidth={2} dot={false} isAnimationActive={false} />
             </LineChart>
           </ResponsiveContainer>

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { formatDate } from "./dates";
+
+describe("formatDate", () => {
+  it("formats valid ISO date", () => {
+    expect(formatDate("2024-03-15")).toBe("15/03/2024");
+  });
+
+  it("returns input for invalid date", () => {
+    expect(formatDate("invalid" as any)).toBe("invalid");
+  });
+});

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,8 @@
+export function formatDate(str: string): string {
+  const d = new Date(str);
+  if (Number.isNaN(d.getTime())) return str;
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = d.getFullYear();
+  return `${dd}/${mm}/${yyyy}`;
+}


### PR DESCRIPTION
## Summary
- add shared `formatDate` utility
- use `formatDate` in harvest history components and spots history route
- cover date formatting with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f117f5ff483298adc1f6fda9adab6