### PR TITLE
feat: refine spot history page

### DIFF
--- a/src/components/history/HarvestList.tsx
+++ b/src/components/history/HarvestList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import type { VisitHistory } from "@/types";
 import { useT } from "@/i18n";
 import { Stars } from "@/components/common/Stars";
@@ -15,15 +16,15 @@ export function HarvestList({ items, onEdit, onDelete }: HarvestListProps) {
   const { t } = useT();
 
   return (
-    <ul className="space-y-4">
+    <ul className="space-y-3">
       {items.map((h) => {
         const date = formatDate(h.date);
         return (
           <li key={h.id}>
-            <div
+            <Card
               tabIndex={0}
               role="button"
-              className="p-4 border border-border rounded-md space-y-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="p-4 space-y-2 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               onClick={() => onEdit(h.id)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") onEdit(h.id);
@@ -62,7 +63,7 @@ export function HarvestList({ items, onEdit, onDelete }: HarvestListProps) {
                   {t("Supprimer")}
                 </Button>
               </div>
-            </div>
+            </Card>
           </li>
         );
       })}

--- a/src/routes/spots/History.test.tsx
+++ b/src/routes/spots/History.test.tsx
@@ -4,6 +4,7 @@ import "@testing-library/jest-dom";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import History from "./History";
 import { AppProvider } from "@/context/AppContext";
+import { MemoryRouter } from "react-router-dom";
 
 describe("History page", () => {
   beforeEach(() => {
@@ -43,9 +44,11 @@ describe("History page", () => {
 
   it("renders base layout", () => {
     render(
-      <AppProvider>
-        <History />
-      </AppProvider>
+      <MemoryRouter>
+        <AppProvider>
+          <History />
+        </AppProvider>
+      </MemoryRouter>
     );
     expect(screen.getByText("Mon coin")).toBeInTheDocument();
     expect(screen.getByText("Ajouter une cueillette")).toBeInTheDocument();
@@ -54,9 +57,11 @@ describe("History page", () => {
 
   it("opens and closes modal", () => {
     render(
-      <AppProvider>
-        <History />
-      </AppProvider>
+      <MemoryRouter>
+        <AppProvider>
+          <History />
+        </AppProvider>
+      </MemoryRouter>
     );
     fireEvent.click(screen.getByText("Ajouter une cueillette"));
     expect(screen.getByRole("heading", { name: "Ajouter une cueillette" })).toBeInTheDocument();

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useT } from "@/i18n";
 import { useAppContext } from "@/context/AppContext";
@@ -10,6 +12,7 @@ import HarvestListSkeleton from "@/components/history/HarvestListSkeleton";
 import ChartSkeleton from "@/components/history/ChartSkeleton";
 import HarvestModal, { Harvest } from "@/components/harvest/HarvestModal";
 import { formatDate } from "@/utils";
+import { BTN_GHOST_ICON, T_PRIMARY } from "@/styles/tokens";
 import {
   ResponsiveContainer,
   LineChart,
@@ -24,6 +27,7 @@ import {
 export default function History() {
   const { t } = useT();
   const { state, dispatch } = useAppContext();
+  const navigate = useNavigate();
   const spot = state.mySpots[0] || {
     id: 1,
     name: t("Mon coin"),
@@ -80,8 +84,21 @@ export default function History() {
   const current = modalId !== null ? history.find((h) => h.id === modalId) : undefined;
 
   return (
-    <section className="p-4 space-y-4">
-      <h1 className="text-xl font-semibold">{spot.name}</h1>
+    <section className="p-3 space-y-3">
+      <div className="relative h-10">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate(-1)}
+          className={`absolute left-0 ${BTN_GHOST_ICON}`}
+          aria-label={t("Retour")}
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </Button>
+        <h2 className={`absolute inset-0 grid place-items-center text-lg font-semibold pointer-events-none ${T_PRIMARY}`}>
+          {spot.name}
+        </h2>
+      </div>
       <div style={{ height: 240 }}>
         {chartLoading ? (
           <ChartSkeleton />
@@ -97,8 +114,8 @@ export default function History() {
           </ResponsiveContainer>
         )}
       </div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div className="space-y-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <div className="space-y-3">
           <Button onClick={() => { setModalId(null); setModalOpen(true); }}>
             {t("Ajouter une cueillette")}
           </Button>


### PR DESCRIPTION
## Summary
- add back button and responsive layout to spot history page
- refactor harvest list items to use Card component
- wrap tests with router context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f1abb8d688329a7aae0acde7677f1