### PR TITLE
refactor: share coin form for harvest

### DIFF
--- a/src/components/CoinFormBase.tsx
+++ b/src/components/CoinFormBase.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useRef } from "react";
+import { X, Image } from "lucide-react";
+import { Select } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { MUSHROOMS } from "@/data/mushrooms";
+import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "@/styles/tokens";
+import { StarRating } from "./StarRating";
+import { useT } from "@/i18n";
+
+interface CoinFormBaseProps {
+  species: string[];
+  setSpecies: (s: string[]) => void;
+  date: string;
+  setDate: (v: string) => void;
+  rating: number;
+  setRating: (v: number) => void;
+  photos: string[];
+  setPhotos: (p: string[]) => void;
+  dateError?: string;
+}
+
+export function CoinFormBase({
+  species,
+  setSpecies,
+  date,
+  setDate,
+  rating,
+  setRating,
+  photos,
+  setPhotos,
+  dateError,
+}: CoinFormBaseProps) {
+  const { t } = useT();
+  const photoUrlsRef = useRef<string[]>([]);
+
+  const importImages = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length === 0) return;
+    const urls = files.map((f) => URL.createObjectURL(f));
+    photoUrlsRef.current.push(...urls);
+    setPhotos((p) => [...p, ...urls]);
+  };
+
+  useEffect(() => {
+    const current = new Set(photos);
+    photoUrlsRef.current = photoUrlsRef.current.filter((url) => {
+      if (!current.has(url)) {
+        URL.revokeObjectURL(url);
+        return false;
+      }
+      return true;
+    });
+  }, [photos]);
+
+  useEffect(() => {
+    return () => {
+      photoUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Champignons trouvés")}</div>
+        <div className="flex flex-wrap gap-2 mb-2">
+          {species.map((id) => (
+            <span
+              key={id}
+              className="inline-flex items-center gap-1 bg-neutral-200 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-full px-2 py-1 text-xs"
+            >
+              <span className={T_PRIMARY}>{MUSHROOMS.find((m) => m.id === id)?.name.split(" ")[0]}</span>
+              <button
+                onClick={() => setSpecies(species.filter((x) => x !== id))}
+                className="text-neutral-400 hover:text-neutral-200"
+                aria-label={t("supprimer")}
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+        <Select
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v) setSpecies(species.includes(v) ? species : [...species, v]);
+          }}
+          value=""
+          className="rounded-xl"
+        >
+          <option value="" disabled>
+            {t("Ajouter un champignon…")}
+          </option>
+          {MUSHROOMS.filter((m) => !species.includes(m.id)).map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      <div>
+        <div className={`text-sm ${T_PRIMARY}`}>{t("Dernière cueillette")}</div>
+        <div className="mt-1">
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm"
+          />
+          {dateError && <p className="text-xs text-danger mt-1">{dateError}</p>}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className={`text-sm ${T_MUTED}`}>{t("Note")}</span>
+        <StarRating value={rating} onSelectIndex={(i) => setRating(5 - i)} />
+        <span className={`text-xs ${T_SUBTLE}`}>{rating}/5</span>
+      </div>
+
+      <div className="pt-2 border-t border-neutral-300 dark:border-neutral-800">
+        <div className="flex items-center justify-between mb-2">
+          <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
+          <label className="inline-flex items-center">
+            <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
+            <Button type="button" className={BTN}>
+              <Image className="w-4 h-4 mr-2" />
+              {t("Importer des photos")}
+            </Button>
+          </label>
+        </div>
+        {photos.length > 0 && (
+          <div className="grid grid-cols-4 gap-2">
+            {photos.map((p, i) => (
+              <img
+                key={i}
+                src={p}
+                className="w-full h-20 object-cover rounded-lg border border-neutral-300 dark:border-neutral-800"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default CoinFormBase;

--- a/src/components/CreateSpotModal.tsx
+++ b/src/components/CreateSpotModal.tsx
@@ -1,16 +1,14 @@
-import React, { useState, useRef, useEffect } from "react";
-import { X, Image } from "lucide-react";
+import React, { useState, useRef } from "react";
+import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Select } from "@/components/ui/select";
 import { MUSHROOMS } from "../data/mushrooms";
-import { BTN, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
-import { StarRating } from "./StarRating";
+import { BTN, T_PRIMARY } from "../styles/tokens";
 import { useT } from "../i18n";
 import type { Spot } from "../types";
 import { todayISO } from "../utils";
-import { loadMap } from "@/services/openstreetmap";
-import Logo from "@/assets/logo.png";
+import CoinFormBase from "./CoinFormBase";
+import LocationSection from "./LocationSection";
 
 export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; onCreate: (spot: Spot) => void }) {
   const today = todayISO();
@@ -22,60 +20,6 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
   const [last, setLast] = useState(today);
   const [location, setLocation] = useState("");
   const [photos, setPhotos] = useState<string[]>([]);
-  const photoUrlsRef = useRef<string[]>([]);
-  const mapContainerRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<any>(null);
-
-  const importImages = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files || []);
-    if (files.length === 0) return;
-    const urls = files.map((f) => URL.createObjectURL(f));
-    photoUrlsRef.current.push(...urls);
-    setPhotos((p) => [...p, ...urls]);
-  };
-
-  useEffect(() => {
-    const current = new Set(photos);
-    photoUrlsRef.current = photoUrlsRef.current.filter((url) => {
-      if (!current.has(url)) {
-        URL.revokeObjectURL(url);
-        return false;
-      }
-      return true;
-    });
-  }, [photos]);
-
-  useEffect(() => {
-    return () => {
-      photoUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
-    };
-  }, []);
-
-  useEffect(() => {
-    if (mapRef.current || !mapContainerRef.current) return;
-    loadMap().then(maplibregl => {
-      const map = new maplibregl.Map({
-        container: mapContainerRef.current as HTMLDivElement,
-        style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
-        center: [2.3522, 48.8566],
-        zoom: 10,
-      });
-      mapRef.current = map;
-      map.on("load", () => map.resize());
-
-      const updateLocation = () => {
-        const c = map.getCenter();
-        setLocation(`${c.lat.toFixed(5)}, ${c.lng.toFixed(5)}`);
-      };
-
-      updateLocation();
-      map.on("moveend", updateLocation);
-    });
-    return () => {
-      mapRef.current?.remove();
-      mapRef.current = null;
-    };
-  }, []);
 
   const handleOutside = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === overlayRef.current) onClose();
@@ -84,7 +28,17 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
   const create = () => {
     const cover = photos[0] || MUSHROOMS[0].photo;
     const history = [{ date: last, rating, note: t("Création"), photos: photos.slice(0, 3) }];
-    onCreate({ id: Date.now(), name, species, rating, last, location, cover, photos: photos.length ? photos : [cover], history });
+    onCreate({
+      id: Date.now(),
+      name,
+      species,
+      rating,
+      last,
+      location,
+      cover,
+      photos: photos.length ? photos : [cover],
+      history,
+    });
   };
 
   return (
@@ -92,7 +46,9 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
       <div className="w-full max-w-2xl bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-800 rounded-2xl p-4">
         <div className="flex items-center justify-between mb-2">
           <div className={`text-lg font-semibold ${T_PRIMARY}`}>{t("Nouveau coin")}</div>
-          <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100"><X className="w-5 h-5" /></button>
+          <button onClick={onClose} className="text-neutral-400 hover:text-neutral-100">
+            <X className="w-5 h-5" />
+          </button>
         </div>
 
         <div className="space-y-3">
@@ -102,89 +58,25 @@ export function CreateSpotModal({ onClose, onCreate }: { onClose: () => void; on
             placeholder={t("Nom du coin")}
             className={T_PRIMARY}
           />
-          <div>
-            <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Localisation")}</div>
-            <div className="relative h-48 rounded-xl border border-neutral-400 dark:border-neutral-700 bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
-              <div ref={mapContainerRef} className="absolute inset-0 w-full h-full" />
-              <img
-                src={Logo}
-                className="absolute left-1/2 top-1/2 w-8 h-8 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
-              />
-            </div>
-            <div className={`text-xs mt-1 ${T_MUTED}`}>{t("Déplacez la carte pour choisir la localisation")}</div>
-            <div className={`text-xs mt-1 ${T_PRIMARY}`}>{location}</div>
-          </div>
+          <LocationSection location={location} setLocation={setLocation} />
 
-          <div>
-            <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Champignons trouvés")}</div>
-            <div className="flex flex-wrap gap-2 mb-2">
-              {species.map((id) => (
-                <span key={id} className="inline-flex items-center gap-1 bg-neutral-200 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-full px-2 py-1 text-xs">
-                  <span className={T_PRIMARY}>{MUSHROOMS.find((m) => m.id === id)?.name.split(" ")[0]}</span>
-                  <button
-                    onClick={() => setSpecies((list) => list.filter((x) => x !== id))}
-                    className="text-neutral-400 hover:text-neutral-200"
-                    aria-label={t("supprimer")}
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </span>
-              ))}
-            </div>
-            <Select
-              onChange={(e) => {
-                const v = e.target.value;
-                if (v) setSpecies((list) => (list.includes(v) ? list : [...list, v]));
-              }}
-              value=""
-              className="rounded-xl"
-            >
-              <option value="" disabled>
-                {t("Ajouter un champignon…")}
-              </option>
-              {MUSHROOMS.filter((m) => !species.includes(m.id)).map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.name}
-                </option>
-              ))}
-            </Select>
-          </div>
-
-          <div>
-            <div className={`text-sm ${T_PRIMARY}`}>{t("Dernière cueillette")}</div>
-            <div className="mt-1">
-              <input type="date" value={last} onChange={(e) => setLast(e.target.value)} className="w-full bg-neutral-100 border border-neutral-300 text-neutral-900 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-100 rounded-xl px-3 py-2 text-sm" />
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className={`text-sm ${T_MUTED}`}>{t("Note")}</span>
-            <StarRating value={rating} onSelectIndex={(i) => setRating(5 - i)} />
-            <span className={`text-xs ${T_SUBTLE}`}>{rating}/5</span>
-          </div>
-
-          <div className="pt-2 border-t border-neutral-300 dark:border-neutral-800">
-            <div className="flex items-center justify-between mb-2">
-              <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
-              <label className="inline-flex items-center">
-                <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
-                <Button type="button" className={BTN}>
-                  <Image className="w-4 h-4 mr-2" />
-                  {t("Importer des photos")}
-                </Button>
-              </label>
-            </div>
-            {photos.length > 0 && (
-              <div className="grid grid-cols-4 gap-2">
-                {photos.map((p, i) => (
-                  <img key={i} src={p} className="w-full h-20 object-cover rounded-lg border border-neutral-300 dark:border-neutral-800" />
-                ))}
-              </div>
-            )}
-          </div>
+          <CoinFormBase
+            species={species}
+            setSpecies={setSpecies}
+            date={last}
+            setDate={setLast}
+            rating={rating}
+            setRating={setRating}
+            photos={photos}
+            setPhotos={setPhotos}
+          />
 
           <div className="flex items-center gap-2 justify-end">
-            <Button variant="ghost" onClick={onClose} className={`rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}>
+            <Button
+              variant="ghost"
+              onClick={onClose}
+              className={`rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}
+            >
               {t("Annuler")}
             </Button>
             <Button className={BTN} onClick={create}>

--- a/src/components/LocationSection.tsx
+++ b/src/components/LocationSection.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useRef } from "react";
+import { useT } from "@/i18n";
+import { T_PRIMARY, T_MUTED } from "@/styles/tokens";
+import { loadMap } from "@/services/openstreetmap";
+import Logo from "@/assets/logo.png";
+
+interface LocationSectionProps {
+  location: string;
+  setLocation: (v: string) => void;
+}
+
+export function LocationSection({ location, setLocation }: LocationSectionProps) {
+  const { t } = useT();
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (mapRef.current || !mapContainerRef.current) return;
+    loadMap().then((maplibregl) => {
+      const map = new maplibregl.Map({
+        container: mapContainerRef.current as HTMLDivElement,
+        style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+        center: [2.3522, 48.8566],
+        zoom: 10,
+      });
+      mapRef.current = map;
+      map.on("load", () => map.resize());
+
+      const updateLocation = () => {
+        const c = map.getCenter();
+        setLocation(`${c.lat.toFixed(5)}, ${c.lng.toFixed(5)}`);
+      };
+
+      updateLocation();
+      map.on("moveend", updateLocation);
+    });
+    return () => {
+      mapRef.current?.remove();
+      mapRef.current = null;
+    };
+  }, [setLocation]);
+
+  return (
+    <div>
+      <div className={`text-sm mb-1 ${T_PRIMARY}`}>{t("Localisation")}</div>
+      <div className="relative h-48 rounded-xl border border-neutral-400 dark:border-neutral-700 bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
+        <div ref={mapContainerRef} className="absolute inset-0 w-full h-full" />
+        <img
+          src={Logo}
+          className="absolute left-1/2 top-1/2 w-8 h-8 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+        />
+      </div>
+      <div className={`text-xs mt-1 ${T_MUTED}`}>{t("Déplacez la carte pour choisir la localisation")}</div>
+      <div className={`text-xs mt-1 ${T_PRIMARY}`}>{location}</div>
+    </div>
+  );
+}
+
+export default LocationSection;

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -13,6 +13,7 @@ import ChartSkeleton from "@/components/history/ChartSkeleton";
 import HarvestModal, { Harvest } from "@/components/harvest/HarvestModal";
 import { formatDate } from "@/utils";
 import { BTN_GHOST_ICON, T_PRIMARY } from "@/styles/tokens";
+import { MUSHROOMS } from "@/data/mushrooms";
 import {
   ResponsiveContainer,
   LineChart,
@@ -50,11 +51,15 @@ export default function History() {
   }, [history]);
 
   const saveHarvest = (h: Harvest) => {
+    const note = h.species
+      .map((id) => MUSHROOMS.find((m) => m.id === id)?.name.split(" ")[0])
+      .filter(Boolean)
+      .join(", ");
     const visit: VisitHistory = {
       id: modalId || crypto.randomUUID(),
       date: h.date,
       rating: h.rating,
-      note: h.comment,
+      note,
       photos: h.photos,
     };
     let newHistory: VisitHistory[];
@@ -143,7 +148,11 @@ export default function History() {
           setModalOpen(false);
           setModalId(null);
         }}
-        initial={current ? { ...current, comment: current.note } : undefined}
+        initial={
+          current
+            ? { id: current.id, date: current.date, rating: current.rating, species: [], photos: current.photos }
+            : undefined
+        }
         onSave={saveHarvest}
         onDelete={current ? () => { deleteHarvest(modalId!); setModalOpen(false); setModalId(null); } : undefined}
       />


### PR DESCRIPTION
## Summary
- extract CoinFormBase and LocationSection components from spot creation
- rebuild HarvestModal using CoinFormBase without location section
- wire history page to new harvest modal and note generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f20156e308329b0080a78849390a9