### PR TITLE
Fix static fallback for spot map in history

### DIFF
--- a/src/components/history/MapSpotCard.tsx
+++ b/src/components/history/MapSpotCard.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { loadMap } from "@/services/openstreetmap";
+import { loadMap, getStaticMapUrl } from "@/services/openstreetmap";
 import type { StyleSpecification } from "maplibre-gl";
 import { useT } from "@/i18n";
 
@@ -9,42 +9,47 @@ export function MapSpotCard({ center }: { center: [number, number] }) {
   const { t } = useT();
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<any>(null);
+  const [fallbackUrl, setFallbackUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (!mapContainer.current) return;
     const [lat, lng] = center;
-    loadMap().then((maplibregl) => {
-      const style: StyleSpecification = {
-        version: 8,
-        sources: {
-          osm: {
-            type: "raster",
-            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-            tileSize: 256,
+    loadMap()
+      .then((maplibregl) => {
+        const style: StyleSpecification = {
+          version: 8,
+          sources: {
+            osm: {
+              type: "raster",
+              tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+              tileSize: 256,
+            },
           },
-        },
-        layers: [
-          {
-            id: "osm",
-            type: "raster",
-            source: "osm",
-            minzoom: 0,
-            maxzoom: 19,
-          },
-        ],
-      };
-      const map = new maplibregl.Map({
-        container: mapContainer.current as HTMLDivElement,
-        style,
-        center: [lng, lat],
-        zoom: 12,
-        attributionControl: false,
+          layers: [
+            {
+              id: "osm",
+              type: "raster",
+              source: "osm",
+              minzoom: 0,
+              maxzoom: 19,
+            },
+          ],
+        };
+        const map = new maplibregl.Map({
+          container: mapContainer.current as HTMLDivElement,
+          style,
+          center: [lng, lat],
+          zoom: 12,
+          attributionControl: false,
+        });
+        mapRef.current = map;
+        new maplibregl.Marker().setLngLat([lng, lat]).addTo(map);
+      })
+      .catch(() => {
+        setFallbackUrl(getStaticMapUrl(lat, lng));
       });
-      mapRef.current = map;
-      new maplibregl.Marker().setLngLat([lng, lat]).addTo(map);
-    });
     return () => mapRef.current?.remove();
-  }, [center]);
+  }, [center[0], center[1]]);
 
   const [lat, lng] = center;
   const openRoute = () => {
@@ -62,7 +67,11 @@ export function MapSpotCard({ center }: { center: [number, number] }) {
           role="img"
           aria-label={t("Carte de l'emplacement situé aux coordonnées latitude {lat}, longitude {lng}", { lat, lng })}
         >
-          <div ref={mapContainer} className="absolute inset-0" />
+          {fallbackUrl ? (
+            <img src={fallbackUrl} alt="" className="absolute inset-0 w-full h-full object-cover" />
+          ) : (
+            <div ref={mapContainer} className="absolute inset-0" />
+          )}
         </div>
       </CardContent>
       <CardFooter className="pt-2 flex justify-end">


### PR DESCRIPTION
## Summary
- ensure spot history shows map even if interactive tiles fail by falling back to static image
- limit MapSpotCard re-renders by tracking latitude/longitude separately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f288a5038832991b4181b08bc0b42