### PR TITLE
Close harvest modal after save and update last visit

### DIFF
--- a/src/components/harvest/HarvestModal.tsx
+++ b/src/components/harvest/HarvestModal.tsx
@@ -45,6 +45,7 @@ export function HarvestModal({
     setErrors(err);
     if (Object.keys(err).length) return;
     onSave({ id: initial?.id, date, rating, species, photos });
+    onClose();
   };
 
   const title = initial ? t("Modifier la cueillette") : t("Ajouter une cueillette");

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -70,7 +70,10 @@ export default function History() {
     }
     newHistory = newHistory.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
     setHistory(newHistory);
-    dispatch({ type: "updateSpot", spot: { ...spot, history: newHistory } });
+    dispatch({
+      type: "updateSpot",
+      spot: { ...spot, history: newHistory, last: newHistory[0]?.date },
+    });
   };
 
   const deleteHarvest = (id: string) => {


### PR DESCRIPTION
## Summary
- Close harvest modal when saving a cueillette
- Update spot's last visit date when new harvest is saved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f2b968da08329b0bc96633268937e