### PR TITLE
Unify forecast graph between spot views

### DIFF
--- a/src/components/ForecastChart.tsx
+++ b/src/components/ForecastChart.tsx
@@ -1,0 +1,50 @@
+import React, { useMemo, useEffect, useRef } from "react";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine } from "recharts";
+import { animate } from "framer-motion";
+import { useAppContext } from "@/context/AppContext";
+import { generateForecast } from "@/utils";
+
+export function ForecastChart({ className = "" }: { className?: string }) {
+  const { state } = useAppContext();
+  const data = useMemo(() => generateForecast(state.prefs.lang), [state.prefs.lang]);
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const path = chartRef.current?.querySelector(".recharts-line-curve") as SVGPathElement | null;
+    if (!path) return;
+    const length = path.getTotalLength();
+    path.style.strokeDasharray = `${length}`;
+    path.style.strokeDashoffset = `${length}`;
+    animate(path, { strokeDashoffset: 0 }, { duration: 1.2, ease: "easeInOut" });
+  }, [data]);
+
+  return (
+    <div ref={chartRef} className={`h-56 ${className}`}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 10, right: 10, bottom: 0, left: 0 }}>
+          <XAxis dataKey="day" tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }} interval={3} />
+          <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }} width={28} />
+          <Tooltip
+            contentStyle={{
+              background: "#171717",
+              border: "1px solid #262626",
+              borderRadius: 12,
+              color: "#e5e5e5",
+            }}
+          />
+          <ReferenceLine x={data[7].day} stroke="#525252" strokeDasharray="3 3" />
+          <Line
+            type="monotone"
+            dataKey="score"
+            stroke="hsl(var(--fern-green))"
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export default ForecastChart;

--- a/src/routes/spots/History.test.tsx
+++ b/src/routes/spots/History.test.tsx
@@ -33,7 +33,8 @@ describe("History page", () => {
         XAxis: Mock,
         YAxis: Mock,
         CartesianGrid: Mock,
-        Tooltip: Mock
+        Tooltip: Mock,
+        ReferenceLine: Mock,
       };
     });
   });

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -9,20 +9,10 @@ import LastHarvestCard from "@/components/history/LastHarvestCard";
 import MapSpotCard from "@/components/history/MapSpotCard";
 import HarvestList from "@/components/history/HarvestList";
 import HarvestListSkeleton from "@/components/history/HarvestListSkeleton";
-import ChartSkeleton from "@/components/history/ChartSkeleton";
 import HarvestModal, { Harvest } from "@/components/harvest/HarvestModal";
-import { formatDate } from "@/utils";
 import { BTN_GHOST_ICON, T_PRIMARY } from "@/styles/tokens";
 import { MUSHROOMS } from "@/data/mushrooms";
-import {
-  ResponsiveContainer,
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-} from "recharts";
+import ForecastChart from "@/components/ForecastChart";
 
 
 export default function History() {
@@ -39,16 +29,9 @@ export default function History() {
   const [history, setHistory] = useState<VisitHistory[]>(
     spot.history.map((h) => ({ id: h.id || crypto.randomUUID(), ...h }))
   );
-  const [chartLoading, setChartLoading] = useState(true);
   const [listLoading] = useState(false);
   const [modalId, setModalId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
-
-  useEffect(() => {
-    setChartLoading(true);
-    const timer = setTimeout(() => setChartLoading(false), 300);
-    return () => clearTimeout(timer);
-  }, [history]);
 
   const saveHarvest = (h: Harvest) => {
     const note = h.species
@@ -82,9 +65,6 @@ export default function History() {
     dispatch({ type: "updateSpot", spot: { ...spot, history: newHistory } });
   };
 
-  const data = history.map((h) => ({ date: h.date, value: h.rating }));
-  const ticks = data.length ? data.filter((_, i) => i % Math.ceil(data.length / 6) === 0).map((d) => d.date) : [];
-
   const location = spot.location
     ? spot.location.split(",").map((v) => parseFloat(v.trim()))
     : [48.8566, 2.3522];
@@ -107,21 +87,7 @@ export default function History() {
           {spot.name}
         </h2>
       </div>
-      <div style={{ height: 240 }}>
-        {chartLoading ? (
-          <ChartSkeleton />
-        ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
-              <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="3 3" />
-              <XAxis dataKey="date" ticks={ticks} tickFormatter={formatDate} stroke="hsl(var(--foreground))" tick={{ fill: "hsl(var(--foreground))" }} />
-              <YAxis domain={[0, 5]} stroke="hsl(var(--foreground))" tick={{ fill: "hsl(var(--foreground))" }} />
-              <Tooltip contentStyle={{ background: "hsl(var(--background))", border: "1px solid hsl(var(--border))", borderRadius: 4 }} labelFormatter={(v) => formatDate(v as string)} />
-              <Line type="monotone" dataKey="value" stroke="hsl(var(--forest-green))" strokeWidth={2} dot={false} isAnimationActive={false} />
-            </LineChart>
-          </ResponsiveContainer>
-        )}
-      </div>
+      <ForecastChart />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <div className="space-y-3">
           <Button onClick={() => { setModalId(null); setModalOpen(true); }}>

--- a/src/scenes/SpotDetailsScene.tsx
+++ b/src/scenes/SpotDetailsScene.tsx
@@ -1,16 +1,15 @@
-import React, { useRef, useState, useEffect, useMemo } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { ChevronLeft, Plus, Pencil, Maximize2, Trash2 } from "lucide-react";
-import { animate } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { BTN, BTN_GHOST_ICON, T_PRIMARY, T_MUTED, T_SUBTLE } from "../styles/tokens";
 import { useT } from "../i18n";
 import type { Spot, VisitHistory } from "../types";
-import { todayISO, generateForecast, formatDate } from "../utils";
+import { todayISO, formatDate } from "../utils";
 import { loadMap } from "@/services/openstreetmap";
 import type { StyleSpecification } from "maplibre-gl";
 import Logo from "@/assets/logo.png";
 import { useAppContext } from "../context/AppContext";
-import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine } from "recharts";
+import ForecastChart from "@/components/ForecastChart";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 import { EditVisitModal } from "../components/EditVisitModal";
 
@@ -33,8 +32,6 @@ export default function SpotDetailsScene({ spot, onBack }: { spot: Spot | null; 
   const [confirmOpen, setConfirmOpen] = useState(false);
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<any>(null);
-  const chartRef = useRef<HTMLDivElement | null>(null);
-  const data = useMemo(() => generateForecast(state.prefs.lang), [state.prefs.lang]);
 
   useEffect(() => {
     if (!spot?.location || mapRef.current || !mapContainerRef.current) return;
@@ -76,16 +73,6 @@ export default function SpotDetailsScene({ spot, onBack }: { spot: Spot | null; 
     };
   }, [spot?.location]);
 
-  useEffect(() => {
-    const path = chartRef.current?.querySelector(
-      ".recharts-line-curve"
-    ) as SVGPathElement | null;
-    if (!path) return;
-    const length = path.getTotalLength();
-    path.style.strokeDasharray = `${length}`;
-    path.style.strokeDashoffset = `${length}`;
-    animate(path, { strokeDashoffset: 0 }, { duration: 1.2, ease: "easeInOut" });
-  }, [data]);
 
   if (!spot) return null;
   const photos = spot.photos || [];
@@ -136,39 +123,7 @@ export default function SpotDetailsScene({ spot, onBack }: { spot: Spot | null; 
         <p className={`text-xs mt-2 ${T_SUBTLE}`}>{t("La carte affiche l'historique complet avec détails.")}</p>
 
         <div className="mt-3">
-          <div className="h-56" ref={chartRef}>
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={data} margin={{ top: 10, right: 10, bottom: 0, left: 0 }}>
-                <XAxis
-                  dataKey="day"
-                  tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }}
-                  interval={3}
-                />
-                <YAxis
-                  domain={[0, 100]}
-                  tick={{ fontSize: 10, fill: "hsl(var(--forest-green))" }}
-                  width={28}
-                />
-                <Tooltip
-                  contentStyle={{
-                    background: "#171717",
-                    border: "1px solid #262626",
-                    borderRadius: 12,
-                    color: "#e5e5e5",
-                  }}
-                />
-                <ReferenceLine x={data[7].day} stroke="#525252" strokeDasharray="3 3" />
-                <Line
-                  type="monotone"
-                  dataKey="score"
-                  stroke="hsl(var(--fern-green))"
-                  strokeWidth={2}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
+          <ForecastChart />
           <div className={`mt-2 text-xs ${T_SUBTLE}`}>Prévisions locales (démo)</div>
         </div>
 


### PR DESCRIPTION
## Summary
- add reusable `ForecastChart` for displaying forecast data
- use `ForecastChart` in spot history and details views
- update tests to mock new Recharts component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f33247b6c8329825d5638535923bc