### PR TITLE
feat: add static map fallback

### DIFF
--- a/src/components/__tests__/CreateSpotModal.test.tsx
+++ b/src/components/__tests__/CreateSpotModal.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@/services/openstreetmap', () => ({
       }
     },
   })),
+  getStaticMapUrl: vi.fn(() => ''),
 }));
 
 describe('CreateSpotModal', () => {

--- a/src/routes/spots/History.test.tsx
+++ b/src/routes/spots/History.test.tsx
@@ -8,21 +8,22 @@ import { MemoryRouter } from "react-router-dom";
 
 describe("History page", () => {
   beforeEach(() => {
-    vi.mock("@/services/openstreetmap", () => ({
-      loadMap: vi.fn(async () => ({
-        Map: class {
-          remove() {}
-        },
-        Marker: class {
-          setLngLat() {
-            return this;
+      vi.mock("@/services/openstreetmap", () => ({
+        loadMap: vi.fn(async () => ({
+          Map: class {
+            remove() {}
+          },
+          Marker: class {
+            setLngLat() {
+              return this;
+            }
+            addTo() {
+              return this;
+            }
           }
-          addTo() {
-            return this;
-          }
-        }
-      }))
-    }));
+        })),
+        getStaticMapUrl: vi.fn(() => ""),
+      }));
     vi.mock("recharts", () => {
       const React = require("react");
       const Mock = ({ children }: any) => <div>{children}</div>;

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -45,12 +45,13 @@ vi.mock('../../services/openstreetmap', () => {
     addTo() { return this; }
     remove() {}
   }
-  return {
-    loadMap: vi.fn(() => Promise.resolve({ Map, Marker })),
-    geocode: vi.fn(),
-    reverseGeocode: vi.fn(() => Promise.resolve('Testville')),
-  };
-});
+    return {
+      loadMap: vi.fn(() => Promise.resolve({ Map, Marker })),
+      geocode: vi.fn(),
+      reverseGeocode: vi.fn(() => Promise.resolve('Testville')),
+      getStaticMapUrl: vi.fn(() => ''),
+    };
+  });
 
 describe('MapScene', () => {
   it('opens zone when toast is clicked', async () => {


### PR DESCRIPTION
## Summary
- add static map fallback when MapLibre fails in `MapSpotCard`
- update tests to mock `getStaticMapUrl`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f373c2a4c8329ab420a140613619f