### PR TITLE
Use MapCard with Carto basemap and static fallback

### DIFF
--- a/src/components/history/MapCard.tsx
+++ b/src/components/history/MapCard.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
-import { loadMap } from "@/services/openstreetmap";
+import { loadMap, getStaticMapUrl } from "@/services/openstreetmap";
 import type { StyleSpecification } from "maplibre-gl";
 import { useT } from "@/i18n";
 import Logo from "@/assets/logo.png";
@@ -9,45 +9,62 @@ export function MapCard({ center }: { center: [number, number] }) {
   const { t } = useT();
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<any>(null);
+  const [staticUrl, setStaticUrl] = useState<string | null>(null);
   useEffect(() => {
-    if (!mapContainer.current) return;
     const [lat, lng] = center;
-    loadMap().then(maplibregl => {
-      const style: StyleSpecification = {
-        version: 8,
-        sources: {
-          osm: {
-            type: "raster",
-            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-            tileSize: 256,
-            attribution: t("© OpenStreetMap contributors | MapLibre"),
-          },
-        },
-        layers: [
-          {
-            id: "osm",
-            type: "raster",
-            source: "osm",
-            minzoom: 0,
-            maxzoom: 19,
-          },
-        ],
-      };
-      const map = new maplibregl.Map({
-        container: mapContainer.current as HTMLDivElement,
-        style,
-        center: [lng, lat],
-        zoom: 12,
-        attributionControl: false,
+    if (!mapContainer.current) {
+      setStaticUrl(getStaticMapUrl(lat, lng));
+      return;
+    }
+    loadMap()
+      .then(maplibregl => {
+        try {
+          const style: StyleSpecification = {
+            version: 8,
+            sources: {
+              osm: {
+                type: "raster",
+                tiles: [
+                  "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png",
+                ],
+                tileSize: 256,
+                attribution: t("© OpenStreetMap contributors | MapLibre"),
+              },
+            },
+            layers: [
+              {
+                id: "osm",
+                type: "raster",
+                source: "osm",
+                minzoom: 0,
+                maxzoom: 19,
+              },
+            ],
+          };
+          const map = new maplibregl.Map({
+            container: mapContainer.current as HTMLDivElement,
+            style,
+            center: [lng, lat],
+            zoom: 12,
+            attributionControl: false,
+          });
+          mapRef.current = map;
+          map.on("error", () => {
+            setStaticUrl(getStaticMapUrl(lat, lng));
+          });
+          const el = document.createElement("img");
+          el.src = Logo;
+          el.className = "w-6 h-6";
+          new maplibregl.Marker({ element: el, anchor: "bottom" })
+            .setLngLat([lng, lat])
+            .addTo(map);
+        } catch {
+          setStaticUrl(getStaticMapUrl(lat, lng));
+        }
+      })
+      .catch(() => {
+        setStaticUrl(getStaticMapUrl(lat, lng));
       });
-      mapRef.current = map;
-      const el = document.createElement("img");
-      el.src = Logo;
-      el.className = "w-6 h-6";
-      new maplibregl.Marker({ element: el, anchor: "bottom" })
-        .setLngLat([lng, lat])
-        .addTo(map);
-    });
     return () => mapRef.current?.remove();
   }, [center]);
   const [lat, lng] = center;
@@ -63,7 +80,15 @@ export function MapCard({ center }: { center: [number, number] }) {
           role="img"
           aria-label={t("Carte de l'emplacement situé aux coordonnées latitude {lat}, longitude {lng}", { lat, lng })}
         >
-          <div ref={mapContainer} className="absolute inset-0" />
+          {staticUrl ? (
+            <img
+              src={staticUrl}
+              alt=""
+              className="absolute inset-0 w-full h-full object-cover"
+            />
+          ) : (
+            <div ref={mapContainer} className="absolute inset-0" />
+          )}
         </div>
       </CardContent>
       <CardFooter className="pt-2 flex justify-end">

--- a/src/routes/spots/History.test.tsx
+++ b/src/routes/spots/History.test.tsx
@@ -54,7 +54,6 @@ describe("History page", () => {
     );
     expect(screen.getByText("Mon coin")).toBeInTheDocument();
     expect(screen.getByText("Ajouter une cueillette")).toBeInTheDocument();
-    expect(screen.getByText("Itinéraire")).toBeInTheDocument();
   });
 
   it("opens and closes modal", () => {

--- a/src/routes/spots/History.tsx
+++ b/src/routes/spots/History.tsx
@@ -6,7 +6,7 @@ import { useT } from "@/i18n";
 import { useAppContext } from "@/context/AppContext";
 import type { VisitHistory } from "@/types";
 import LastHarvestCard from "@/components/history/LastHarvestCard";
-import MapSpotCard from "@/components/history/MapSpotCard";
+import MapCard from "@/components/history/MapCard";
 import HarvestList from "@/components/history/HarvestList";
 import HarvestListSkeleton from "@/components/history/HarvestListSkeleton";
 import HarvestModal, { Harvest } from "@/components/harvest/HarvestModal";
@@ -95,7 +95,7 @@ export default function History() {
           </Button>
           <LastHarvestCard harvest={history[0]} />
         </div>
-        <MapSpotCard center={[location[0], location[1]] as [number, number]} />
+        <MapCard center={[location[0], location[1]] as [number, number]} />
       </div>
       <div>
         {listLoading ? (


### PR DESCRIPTION
## Summary
- replace MapSpotCard with MapCard in History route
- render MapCard with Carto "positron" tiles and static fallback via getStaticMapUrl
- update History tests for new map card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f5827b0a08329a0b26c2dd99d22d0