### PR TITLE
Enable horizontal scrolling for mushroom filters

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -87,4 +87,6 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
 
 @layer utilities {
   .container { @apply max-w-screen-xl mx-auto px-4 md:px-6; }
+  .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+  .no-scrollbar::-webkit-scrollbar { display: none; }
 }

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -262,17 +262,29 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
         )}
 
       </div>
-      <div className="mt-4 flex flex-wrap gap-2">
-        {MUSHROOMS.map(m => (
-          <Button
-            key={m.id}
-            onClick={() => toggleShroom(m.id)}
-            className={BTN}
-            variant={selected.includes(m.id) ? "primary" : "secondary"}
-          >
-            {m.name}
-          </Button>
-        ))}
+      <div className="mt-4">
+        <div className="relative -mx-3 px-3">
+          <div className="flex gap-2 overflow-x-auto snap-x snap-mandatory flex-nowrap no-scrollbar pb-1">
+            {MUSHROOMS.map(m => (
+              <Button
+                key={m.id}
+                onClick={() => toggleShroom(m.id)}
+                className={BTN}
+                variant={selected.includes(m.id) ? "primary" : "secondary"}
+              >
+                {m.name}
+              </Button>
+            ))}
+          </div>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-1 left-3 w-8 bg-gradient-to-r from-background via-background/80 to-transparent dark:from-background/80 dark:via-background/40"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-1 right-3 w-8 bg-gradient-to-l from-background via-background/80 to-transparent dark:from-background/80 dark:via-background/40"
+          />
+        </div>
       </div>
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- wrap mushroom filter buttons in a horizontally scrollable container with subtle gradient hints
- add a reusable no-scrollbar utility to hide horizontal scrollbars for a cleaner look

## Testing
- npm run build *(fails: @napi-rs/canvas native module cannot be bundled by Vite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b16aaeb883299c65c549ae3a3394