### PR TITLE
Hide mushroom picker carousel pagination bar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -87,6 +87,17 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
 
 @layer utilities {
   .container { @apply max-w-screen-xl mx-auto px-4 md:px-6; }
-  .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
-  .no-scrollbar::-webkit-scrollbar { display: none; }
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    scrollbar-color: transparent transparent;
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+  .no-scrollbar::-webkit-scrollbar-thumb,
+  .no-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
 }


### PR DESCRIPTION
## Summary
- update the no-scrollbar utility to hide WebKit scrollbar tracks and thumbs
- prevent the mushroom picker carousel from displaying a pagination bar on the map page

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68c9c2233b088329a2881e63677f2f03