### PR TITLE
Improve no-scrollbar utility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -95,9 +95,14 @@ c3VsdD0ibm9pc2VHdW51IiBpbj0iZG9nZSIgZHVyYXRpb249IjAuM3MiIHN0ZC1kZXZpYXRpb249IjAu
   .no-scrollbar::-webkit-scrollbar {
     width: 0;
     height: 0;
+    display: none;
+    background: transparent;
   }
   .no-scrollbar::-webkit-scrollbar-thumb,
-  .no-scrollbar::-webkit-scrollbar-track {
+  .no-scrollbar::-webkit-scrollbar-track,
+  .no-scrollbar::-webkit-scrollbar-track-piece,
+  .no-scrollbar::-webkit-scrollbar-corner {
     background: transparent;
+    border: none;
   }
 }


### PR DESCRIPTION
## Summary
- hide WebKit scrollbars in the `.no-scrollbar` utility by forcing them to be transparent and not rendered
- ensure scrollbar tracks, corners, and thumbs remain invisible to eliminate the carousel pagination bar

## Testing
- npm run build *(fails: `@napi-rs/canvas` native binary cannot be bundled by Vite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c93b9bdc8329b41d94c27ea46e13