### PR TITLE
Refine confirm delete modal presentation

### DIFF
--- a/src/components/ConfirmDeleteModal.tsx
+++ b/src/components/ConfirmDeleteModal.tsx
@@ -1,26 +1,38 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
-import { BTN, T_PRIMARY } from "../styles/tokens";
+import { T_PRIMARY } from "../styles/tokens";
 import { useT } from "../i18n";
 
 export function ConfirmDeleteModal({ open, onConfirm, onCancel }: { open: boolean; onConfirm: () => void; onCancel: () => void }) {
   const { t } = useT();
   return (
-    <Modal open={open} onClose={onCancel}>
-      <div className="space-y-4">
-        <p className={`text-center ${T_PRIMARY}`}>{t("Supprimer ce coin ?")}</p>
-        <div className="flex justify-end gap-2">
-          <Button
-            variant="ghost"
-            onClick={onCancel}
-            className={`rounded-xl hover:bg-neutral-200 dark:hover:bg-neutral-800 ${T_PRIMARY}`}
-          >
-            {t("Annuler")}
-          </Button>
-          <Button variant="destructive" onClick={onConfirm} className={BTN}>
-            {t("Supprimer")}
-          </Button>
+    <Modal
+      open={open}
+      onClose={onCancel}
+      contentClassName="max-w-xs w-[min(90vw,20rem)] rounded-3xl overflow-hidden p-0"
+    >
+      <div className="flex flex-col">
+        <div className="space-y-3 px-6 pt-6 pb-4 text-center">
+          <p className={`text-base font-semibold ${T_PRIMARY}`}>{t("Supprimer ce coin ?")}</p>
+        </div>
+        <div className="border-t border-border">
+          <div className="flex flex-col divide-y divide-border">
+            <Button
+              variant="ghost"
+              onClick={onCancel}
+              className={`w-full rounded-none py-4 text-base ${T_PRIMARY}`}
+            >
+              {t("Annuler")}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={onConfirm}
+              className="w-full rounded-none py-4 text-base"
+            >
+              {t("Supprimer")}
+            </Button>
+          </div>
         </div>
       </div>
     </Modal>

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 
-export function Modal({ open, onClose, children }: { open: boolean; onClose: () => void; children: React.ReactNode }) {
+export function Modal({
+  open,
+  onClose,
+  children,
+  contentClassName,
+}: {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  contentClassName?: string;
+}) {
   if (!open) return null;
   return (
     <div
@@ -10,7 +20,7 @@ export function Modal({ open, onClose, children }: { open: boolean; onClose: () 
       onClick={onClose}
     >
       <div
-        className="bg-background rounded-lg shadow-lg p-6 max-w-lg w-full"
+        className={`bg-background rounded-lg shadow-lg p-6 max-w-lg w-full ${contentClassName ?? ""}`}
         onClick={e => e.stopPropagation()}
       >
         {children}


### PR DESCRIPTION
## Summary
- allow overriding modal content styling with an optional class name
- redesign the confirm delete modal to match an iOS-style stacked action sheet

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68caa5c689d08329a1b1e072fcf61459