### PR TITLE
Handle synchronous geolocation errors

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -265,12 +265,28 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
       notifyGpsError(message, err.message);
     };
 
-    const watchId = navigator.geolocation.watchPosition(success, error, {
-      enableHighAccuracy: true,
-      maximumAge: 0,
-      timeout: 20000,
-    });
-    watchIdRef.current = watchId;
+    try {
+      const watchId = navigator.geolocation.watchPosition(success, error, {
+        enableHighAccuracy: true,
+        maximumAge: 0,
+        timeout: 20000,
+      });
+      watchIdRef.current = watchId;
+    } catch (err) {
+      stopGpsTracking();
+      setGpsFollow(false);
+      const details =
+        err instanceof Error
+          ? `${err.name ? `${err.name}: ` : ""}${err.message}`
+          : undefined;
+      notifyGpsError(
+        "Localisation indisponible",
+        `La géolocalisation n'est pas disponible dans ce contexte.${
+          details ? `\n${details}` : ""
+        }`
+      );
+      return;
+    }
 
     return () => {
       clearGpsWatcher();


### PR DESCRIPTION
## Summary
- guard the geolocation watcher setup so synchronous exceptions stop tracking gracefully
- surface a user-facing notification when geolocation is unavailable in the current context

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caa9d562848329907a7a1edc2c3aa4