### PR TITLE
Use refs to trigger photo upload buttons

### DIFF
--- a/src/components/CoinFormBase.tsx
+++ b/src/components/CoinFormBase.tsx
@@ -32,6 +32,7 @@ export function CoinFormBase({
 }: CoinFormBaseProps) {
   const { t } = useT();
   const photoUrlsRef = useRef<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const importImages = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
@@ -120,13 +121,20 @@ export function CoinFormBase({
       <div className="pt-2 border-t border-neutral-300 dark:border-neutral-800">
         <div className="flex items-center justify-between mb-2">
           <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
-          <label className="inline-flex items-center">
-            <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
-            <Button type="button" className={BTN}>
+          <div className="inline-flex items-center">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={importImages}
+            />
+            <Button type="button" className={BTN} onClick={() => fileInputRef.current?.click()}>
               <Image className="w-4 h-4 mr-2" />
               {t("Importer des photos")}
             </Button>
-          </label>
+          </div>
         </div>
         {photos.length > 0 && (
           <div className="grid grid-cols-4 gap-2">

--- a/src/components/EditSpotModal.tsx
+++ b/src/components/EditSpotModal.tsx
@@ -19,6 +19,7 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: Spot; onClose: 
   const [location, setLocation] = useState(spot.location || "");
   const [photos, setPhotos] = useState<string[]>(spot.photos || [spot.cover].filter(Boolean));
   const photoUrlsRef = useRef<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const { t } = useT();
 
   const importImages = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -125,13 +126,20 @@ export function EditSpotModal({ spot, onClose, onSave }: { spot: Spot; onClose: 
         <div className="mt-3 pt-3 border-t border-neutral-300 dark:border-neutral-800">
           <div className="flex items-center justify-between mb-2">
             <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
-            <label className="inline-flex items-center">
-              <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
-                <Button type="button" className={BTN}>
-                  <Image className="w-4 h-4 mr-2" />
+            <div className="inline-flex items-center">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                onChange={importImages}
+              />
+              <Button type="button" className={BTN} onClick={() => fileInputRef.current?.click()}>
+                <Image className="w-4 h-4 mr-2" />
                 {t("Importer des photos")}
               </Button>
-            </label>
+            </div>
           </div>
           {photos.length > 0 && (
             <div className="grid grid-cols-4 gap-2">

--- a/src/components/EditVisitModal.tsx
+++ b/src/components/EditVisitModal.tsx
@@ -20,6 +20,7 @@ export function EditVisitModal({ visit, onClose, onSave, onDelete }: Props) {
   const [note, setNote] = useState(visit.note || "");
   const [photos, setPhotos] = useState<string[]>(visit.photos || []);
   const photoUrlsRef = useRef<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const { t } = useT();
 
   const handleOutside = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -81,13 +82,20 @@ export function EditVisitModal({ visit, onClose, onSave, onDelete }: Props) {
           <div>
             <div className="flex items-center justify-between mb-2">
               <div className={`text-sm ${T_PRIMARY}`}>{t("Photos")}</div>
-              <label className="inline-flex items-center">
-                <input type="file" accept="image/*" multiple className="hidden" onChange={importImages} />
-                <Button type="button" className={BTN}>
+              <div className="inline-flex items-center">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  className="hidden"
+                  onChange={importImages}
+                />
+                <Button type="button" className={BTN} onClick={() => fileInputRef.current?.click()}>
                   <Image className="w-4 h-4 mr-2" />
                   {t("Importer des photos")}
                 </Button>
-              </label>
+              </div>
             </div>
             {photos.length > 0 && (
               <div className="grid grid-cols-3 gap-2">


### PR DESCRIPTION
## Summary
- replace label-wrapped upload controls with ref-backed hidden inputs triggered by buttons
- reuse the same ref-driven pattern across CoinFormBase, EditVisitModal, and EditSpotModal to open the chooser on click

## Testing
- npm run build *(fails: vite build cannot bundle @napi-rs/canvas native module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2562f5edc8329971b78634373d7f4