### PR TITLE
fix share badge layering and expose primary tokens

### DIFF
--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -298,7 +298,7 @@ export default function SpotsScene({ onBack, onOpenSpot }: { onBack: () => void;
                     }}
                     aria-pressed={isSelected}
                     aria-label={isSelected ? t("Retirer de la sélection") : t("Ajouter à la sélection")}
-                    className="absolute top-3 left-3 w-9 h-9 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary"
+                    className="absolute top-3 left-3 z-10 w-9 h-9 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary"
                   >
                     <span
                       className={`flex h-full w-full items-center justify-center rounded-full border-2 backdrop-blur-sm shadow transition-all ${

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,6 +14,8 @@ module.exports = {
         border: "hsl(var(--border))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        primary: "hsl(var(--forest-green))",
+        "primary-foreground": "hsl(var(--paper-beige))",
         accent: "hsl(var(--accent))",
         forest: "hsl(var(--forest-green))",
         moss: "hsl(var(--moss-green))",


### PR DESCRIPTION
## Summary
- ensure the share-mode selection badge sits above card previews
- expose primary and primary-foreground colors in Tailwind so related utilities are generated

## Testing
- npm run build *(fails: Vite cannot bundle native @napi-rs/canvas binary in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b3c211e88329b7c8cc1b9918ee58