### PR TITLE
Affiche un cercle de sélection vide pour l'export KMZ

### DIFF
--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -304,7 +304,7 @@ export default function SpotsScene({ onBack, onOpenSpot }: { onBack: () => void;
                       className={`flex h-full w-full items-center justify-center rounded-full border-2 backdrop-blur-sm shadow transition-all ${
                         isSelected
                           ? "border-primary bg-primary text-primary-foreground"
-                          : "border-primary/70 bg-background/90 text-transparent"
+                          : "border-primary bg-transparent text-transparent"
                       }`}
                     >
                       <Check className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- ajuste l'état non sélectionné des pastilles de partage pour afficher un cercle vert vide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b532d88083299eaeb3872af16214