### PR TITLE
Adjust share mode badge styling

### DIFF
--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -301,10 +301,10 @@ export default function SpotsScene({ onBack, onOpenSpot }: { onBack: () => void;
                     className="absolute top-3 left-3 z-10 w-9 h-9 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary"
                   >
                     <span
-                      className={`flex h-full w-full items-center justify-center rounded-full backdrop-blur-sm shadow transition-all ${
+                      className={`flex h-full w-full items-center justify-center rounded-full transition-all ${
                         isSelected
-                          ? "border-2 border-primary bg-primary text-primary-foreground"
-                          : "border-[5px] border-primary bg-transparent text-transparent"
+                          ? "backdrop-blur-sm shadow border-2 border-primary bg-primary text-primary-foreground"
+                          : "border-[5px] border-primary bg-transparent text-transparent shadow-none"
                       }`}
                     >
                       <Check className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- tweak the share-mode selection badge so the blur and shadow only apply to the selected state, keeping the unselected badge transparent

## Testing
- npm run build *(fails: Vite cannot bundle native `@napi-rs/canvas` binary)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bbf3c9f8832990f3ca47796d8011