### PR TITLE
Add border-5 utility and update spot indicator

### DIFF
--- a/src/scenes/SpotsScene.tsx
+++ b/src/scenes/SpotsScene.tsx
@@ -304,7 +304,7 @@ export default function SpotsScene({ onBack, onOpenSpot }: { onBack: () => void;
                       className={`flex h-full w-full items-center justify-center rounded-full transition-all ${
                         isSelected
                           ? "backdrop-blur-sm shadow border-2 border-primary bg-primary text-primary-foreground"
-                          : "border-[5px] border-primary bg-transparent text-transparent shadow-none"
+                          : "border-5 border-primary bg-transparent text-transparent shadow-none"
                       }`}
                     >
                       <Check className="h-4 w-4" />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -34,6 +34,9 @@ module.exports = {
         md: "var(--radius-md)",
         lg: "var(--radius-lg)",
       },
+      borderWidth: {
+        5: "5px",
+      },
       boxShadow: {
         sm: "var(--shadow-sm)",
         md: "var(--shadow-md)",


### PR DESCRIPTION
## Summary
- add a dedicated 5px border width utility to the Tailwind theme
- switch the spot selection indicator to use the new border-5 class instead of an arbitrary value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5be1e96b88329a8e2bd4ecf842c93