### PR TITLE
Fix Boletus raster tile path

### DIFF
--- a/src/config/rasterLayers.ts
+++ b/src/config/rasterLayers.ts
@@ -52,7 +52,7 @@ export const RASTER_LAYERS: RasterLayer[] = [
     id: "boletus-edulis",
     title: "Boletus edulis suitability",
     species: ["cepe_de_bordeaux", "boletus_edulis"],
-    url: `${baseUrl}/boletus_edulis/tiles/{z}/{x}/{y}.png`,
+    url: `${baseUrl}/tiles/boletus_edulis/{z}/{x}/{y}.png`,
     minzoom: 6,
     maxzoom: 16,
     opacity: 0.7,


### PR DESCRIPTION
## Summary
- correct the Boletus edulis raster tile URL to match the tiles folder structure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3cd1e5fec8329a2cd5bf2c707dce9