### PR TITLE
Limit active mushroom map layers to three

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -14,6 +14,19 @@ import { RASTER_LAYERS, effectiveBounds } from "@/config/rasterLayers";
 import { useT } from "../i18n";
 import type { Zone } from "../types";
 
+const MAX_ACTIVE_MUSHROOM_MAPS = 3;
+
+export function getNextMushroomSelection(previous: string[], id: string) {
+  if (previous.includes(id)) {
+    return previous.filter(selectedId => selectedId !== id);
+  }
+
+  const next = [...previous, id];
+  return next.length > MAX_ACTIVE_MUSHROOM_MAPS
+    ? next.slice(next.length - MAX_ACTIVE_MUSHROOM_MAPS)
+    : next;
+}
+
 function Toast({
   message,
   details,
@@ -104,9 +117,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
     [setToasts]
   );
   const toggleShroom = (id: string) =>
-    setSelected(prev =>
-      prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]
-    );
+    setSelected(prev => getNextMushroomSelection(prev, id));
 
   const applyRasterVisibility = useCallback((map: any, selection: string[]) => {
     RASTER_LAYERS.forEach(layer => {
@@ -590,6 +601,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
                   onClick={() => toggleShroom(m.id)}
                   className={classNames(BTN, "shrink-0 snap-start")}
                   variant={selected.includes(m.id) ? "primary" : "secondary"}
+                  aria-pressed={selected.includes(m.id)}
                 >
                   {m.name}
                 </Button>

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi, describe, it, expect } from 'vitest';
 
-import MapScene from '../MapScene';
+import MapScene, { getNextMushroomSelection } from '../MapScene';
 import { AppProvider } from '@/context/AppContext';
 import { reverseGeocode } from '../../services/openstreetmap';
 
@@ -58,6 +58,41 @@ vi.mock('../../services/openstreetmap', () => {
   });
 
 describe('MapScene', () => {
+
+  it('keeps only the three most recently activated mushroom maps', () => {
+    const selection = ['cepe_de_bordeaux', 'girolle', 'morille_commune'];
+
+    expect(getNextMushroomSelection(selection, 'morille_conique')).toEqual([
+      'girolle',
+      'morille_commune',
+      'morille_conique',
+    ]);
+  });
+
+  it('deactivates the first selected mushroom button when a fourth is activated', () => {
+    render(
+      <AppProvider>
+        <MapScene onZone={() => {}} gpsFollow={false} setGpsFollow={() => {}} onBack={() => {}} />
+      </AppProvider>
+    );
+
+    const cepe = screen.getByRole('button', { name: 'Cèpe de Bordeaux' });
+    const girolle = screen.getByRole('button', { name: 'Girolle (Chanterelle)' });
+    const morille = screen.getByRole('button', { name: 'Morille commune' });
+    const morilleConique = screen.getByRole('button', { name: 'Morille conique' });
+
+    expect(cepe).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(girolle);
+    fireEvent.click(morille);
+    fireEvent.click(morilleConique);
+
+    expect(cepe).toHaveAttribute('aria-pressed', 'false');
+    expect(girolle).toHaveAttribute('aria-pressed', 'true');
+    expect(morille).toHaveAttribute('aria-pressed', 'true');
+    expect(morilleConique).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('opens zone when toast is clicked', async () => {
     const onZone = vi.fn();
     render(
@@ -67,8 +102,11 @@ describe('MapScene', () => {
     );
 
     // Wait for map to initialize then simulate a click near a known zone
-    await new Promise(r => setTimeout(r, 0));
-    mapInstance.handlers.click({ lngLat: { lat: 45.7, lng: 5.9 } });
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+      mapInstance.handlers.click({ lngLat: { lat: 45.7, lng: 5.9 } });
+      await Promise.resolve();
+    });
 
     const toast = await screen.findByRole('button', { name: /Testville/ });
     fireEvent.click(toast);
@@ -86,8 +124,11 @@ describe('MapScene', () => {
       </AppProvider>
     );
 
-    await new Promise(r => setTimeout(r, 0));
-    mapInstance.handlers.click({ lngLat: { lat: 0, lng: 0 } });
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+      mapInstance.handlers.click({ lngLat: { lat: 0, lng: 0 } });
+      await Promise.resolve();
+    });
 
     const toast = await screen.findByRole('button', { name: /Pas de champignons ici/ });
     expect(toast).toBeInTheDocument();


### PR DESCRIPTION
### Motivation

- Prevent too many raster mushroom layers being visible at once by capping active species maps to three and making the UI state explicit.

### Description

- Add `MAX_ACTIVE_MUSHROOM_MAPS` and `getNextMushroomSelection(previous, id)` to enforce a FIFO selection policy so enabling a fourth mushroom map removes the earliest active one.
- Replace inline toggle logic with `getNextMushroomSelection` in `MapScene` and expose button state via `aria-pressed` on each mushroom button.
- Add unit tests to `src/scenes/__tests__/MapScene.test.tsx` that assert the three-active-map limit and the button behaviour, and wrap map click simulation in `act(...)` to silence test warnings.

### Testing

- Ran `npm test -- src/scenes/__tests__/MapScene.test.tsx` and the focused tests passed (4 tests passed).
- Ran full test suite with `npm test` and all tests passed (13 files, 32 tests passed).
- Ran `npm run build` which failed due to an existing native `@napi-rs/canvas` `.node` binary being included in the browser build (`skia.linux-x64-gnu.node`), which is unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ac64ac69483299e77a844856f10fc)