### PR TITLE
Mettre à jour l'échelle et les couleurs de la légende de la carte

### DIFF
--- a/src/data/legend.ts
+++ b/src/data/legend.ts
@@ -1,7 +1,7 @@
 export const LEGEND = [
-  { label: ">85", color: "bg-emerald-700" },
-  { label: "84–75", color: "bg-emerald-600" },
-  { label: "74–50", color: "bg-yellow-600" },
-  { label: "49–35", color: "bg-orange-600" },
-  { label: "34–25", color: "bg-red-600" }
+  { label: ">90 %", color: "#00441B" },
+  { label: "90–80 %", color: "#237A3B" },
+  { label: "80–70 %", color: "#5FA45D" },
+  { label: "70–60 %", color: "#A8D5A2" },
+  { label: "60–50 %", color: "#DDEED8" }
 ];

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -565,7 +565,7 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
           <div className="flex flex-col sm:flex-row sm:items-center gap-2">
             {LEGEND.map((l, i) => (
               <div key={i} className="flex items-center gap-1">
-                <div className={classNames("w-3 h-3 rounded", l.color)} />
+                <div className="w-3 h-3 rounded" style={{ backgroundColor: l.color }} />
                 <span className={`text-[10px] ${T_MUTED}`}>{l.label}</span>
               </div>
             ))}


### PR DESCRIPTION
### Motivation
- Aligner la légende de la carte sur les plages en pourcentage et les couleurs hexadécimales demandées pour afficher des intervalles clairs et précises.

### Description
- Remplacement des entrées de la légende dans `src/data/legend.ts` par les labels `>90 %`, `90–80 %`, `80–70 %`, `70–60 %`, `60–50 %` et les couleurs hex `#00441B`, `#237A3B`, `#5FA45D`, `#A8D5A2`, `#DDEED8`.
- Adaptation du rendu dans `src/scenes/MapScene.tsx` pour appliquer la couleur via `style={{ backgroundColor: l.color }}` au lieu d'utiliser des classes Tailwind concaténées.

### Testing
- Exécuté `npm test` avec succès (Test Files 13 passed, Tests 32 passed).
- Exécuté `npm run build` qui a échoué en raison d'un import natif `.node` provenant de `@napi-rs/canvas` pendant la build Vite, problème indépendant du changement de la légende.
- Tentative d'exécution de `npm test -- --runInBand` a échoué car Vitest n'accepte pas l'option `--runInBand`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aca77f5f48329bfeb2da92b66ea43)