### PR TITLE
Add mushroom image asset folder

### DIFF
--- a/public/images/mushrooms/README.md
+++ b/public/images/mushrooms/README.md
@@ -1,0 +1,11 @@
+# Images des champignons
+
+Dépose ici les images utilisées par la liste de champignons affichée sur `/picker`.
+
+Dans Vite, tout fichier placé dans `public/` est servi à la racine du site. Une image ajoutée ici avec le nom `cepe-de-bordeaux.jpg` sera donc référencée avec l'URL :
+
+```ts
+photo: "/images/mushrooms/cepe-de-bordeaux.jpg"
+```
+
+Les entrées de la liste se trouvent dans `src/data/mushrooms.ts` et utilisent la propriété `photo`.


### PR DESCRIPTION
### Motivation
- Provide a clear, dedicated location for local mushroom photos used by the `/picker` scene so entries can reference local assets instead of external URLs.

### Description
- Create `public/images/mushrooms/` and add `public/images/mushrooms/README.md` that documents that Vite serves `public/` at the site root, shows how to reference images (e.g. `photo: "/images/mushrooms/cepe-de-bordeaux.jpg"`), and points to `src/data/mushrooms.ts` which uses the `photo` field.

### Testing
- Ran `npm test` which passed; an attempted `npm run build` failed due to an unrelated bundling error importing the native `@napi-rs/canvas` binary for the browser build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae1d5d9e483299ab7b4a23dd9ea78)