### PR TITLE
Fix GPS startup handling and static map build fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ function AppContent() {
   const [deviceFree, setDeviceFree] = useState(2048);
   type Toast = { id: number; type: "success" | "warn"; text: string };
   const [toasts, setToasts] = useState<Toast[]>([]);
-  const [gpsFollow, setGpsFollow] = useState(true);
+  const [gpsFollow, setGpsFollow] = useState(false);
 
   const { dispatch } = useAppContext();
   const { t } = useT();

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -18,7 +18,7 @@ type Action =
   | { type: "removeSpot"; id: number };
 
 const initialState: AppState = {
-  prefs: { units: "métriques", gps: true, lang: "fr" },
+  prefs: { units: "métriques", gps: false, lang: "fr" },
   alerts: { optimum: true, newZone: false },
   mySpots: [],
 };

--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -256,11 +256,27 @@ export default function MapScene({ onZone, gpsFollow, setGpsFollow, onBack }: { 
       return;
     }
 
-    if (
-      typeof window === "undefined" ||
-      typeof navigator === "undefined" ||
-      !navigator.geolocation
-    ) {
+    if (typeof window === "undefined" || typeof navigator === "undefined") {
+      stopGpsTracking();
+      notifyGpsError(
+        "Localisation indisponible",
+        "La géolocalisation n'est pas disponible dans ce contexte."
+      );
+      setGpsFollow(false);
+      return;
+    }
+
+    if (window.isSecureContext === false) {
+      stopGpsTracking();
+      notifyGpsError(
+        "Localisation indisponible",
+        "Le GPS du navigateur fonctionne uniquement en HTTPS ou sur localhost."
+      );
+      setGpsFollow(false);
+      return;
+    }
+
+    if (!navigator.geolocation) {
       stopGpsTracking();
       notifyGpsError(
         "Localisation indisponible",

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -59,6 +59,64 @@ vi.mock('../../services/openstreetmap', () => {
 
 describe('MapScene', () => {
 
+
+  it('keeps GPS inactive until the user explicitly taps the GPS button', () => {
+    const watchPosition = vi.fn();
+    const setGpsFollow = vi.fn();
+
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        watchPosition,
+        clearWatch: vi.fn(),
+      },
+    });
+
+    render(
+      <AppProvider>
+        <MapScene onZone={() => {}} gpsFollow={false} setGpsFollow={setGpsFollow} onBack={() => {}} />
+      </AppProvider>
+    );
+
+    expect(watchPosition).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'GPS' }));
+
+    expect(setGpsFollow).toHaveBeenCalledWith(expect.any(Function));
+    expect(watchPosition).not.toHaveBeenCalled();
+  });
+
+  it('explains that GPS needs HTTPS or localhost instead of starting a watcher in an insecure context', async () => {
+    const watchPosition = vi.fn();
+    const setGpsFollow = vi.fn();
+
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        watchPosition,
+        clearWatch: vi.fn(),
+      },
+    });
+
+    render(
+      <AppProvider>
+        <MapScene onZone={() => {}} gpsFollow={true} setGpsFollow={setGpsFollow} onBack={() => {}} />
+      </AppProvider>
+    );
+
+    expect(await screen.findByRole('button', { name: /HTTPS ou sur localhost/ })).toBeInTheDocument();
+    expect(watchPosition).not.toHaveBeenCalled();
+    expect(setGpsFollow).toHaveBeenCalledWith(false);
+  });
+
   it('keeps only the three most recently activated mushroom maps', () => {
     const selection = ['cepe_de_bordeaux', 'girolle', 'morille_commune'];
 

--- a/src/services/staticMap.ts
+++ b/src/services/staticMap.ts
@@ -1,3 +1,9 @@
+const NODE_CANVAS_MODULE = '@napi-rs/canvas';
+
+async function loadNodeCanvas() {
+  return import(/* @vite-ignore */ NODE_CANVAS_MODULE);
+}
+
 export async function getStaticMapUrl(
   lat: number,
   lng: number,
@@ -72,7 +78,7 @@ async function loadTile(url: string): Promise<any> {
   ) {
     return loadImageBrowser(arr);
   } else {
-    const { loadImage } = await import(/* @vite-ignore */ '@napi-rs/canvas');
+    const { loadImage } = await loadNodeCanvas();
     return loadImage(Buffer.from(arr));
   }
 }
@@ -89,7 +95,7 @@ async function createCanvas(width: number, height: number): Promise<any> {
       // jsdom may not implement canvas, fall back to node canvas
     }
   }
-  const { createCanvas } = await import(/* @vite-ignore */ '@napi-rs/canvas');
+  const { createCanvas } = await loadNodeCanvas();
   return createCanvas(width, height);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the app from starting geolocation automatically when the map loads so GPS tracking only begins on user intent.
- Provide a clear diagnostic when the browser blocks geolocation because the page is not served over HTTPS or localhost.
- Avoid bundling the native `@napi-rs/canvas` binary into the browser build by treating it as a Node-only fallback.

### Description
- Set the initial `gpsFollow` to `false` in `src/App.tsx` and the initial preferences in `src/context/AppContext.tsx` so GPS is off by default.
- Add explicit context checks in `src/scenes/MapScene.tsx` to detect insecure contexts and missing `navigator.geolocation`, show localized messages, call `stopGpsTracking()`, and call `setGpsFollow(false)` instead of attempting to start a watcher.
- Add two unit tests in `src/scenes/__tests__/MapScene.test.tsx` that assert GPS remains inactive until the user taps the GPS button and that an insecure context displays the HTTPS/localhost diagnostic without starting a watcher.
- Change `src/services/staticMap.ts` to lazy-load `@napi-rs/canvas` via a `loadNodeCanvas()` helper with `/* @vite-ignore */` so the native canvas module is only imported at runtime on Node and not bundled for the browser.

### Testing
- Ran `npm test` (Vitest): all tests passed (`13` test files, `34` tests) and the new `MapScene` tests succeeded.
- Ran `npm run build`: production build completed successfully and produced `dist` (warning about some large assets but build succeeded).
- Attempted `npm test -- --runInBand` which failed because `--runInBand` is a Jest option not supported by Vitest, so tests were run with plain `npm test` instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae292871c832990c4c77dc1b55147)