### PR TITLE
Link mushroom images to species cards

### DIFF
--- a/src/data/mushrooms.ts
+++ b/src/data/mushrooms.ts
@@ -1,5 +1,7 @@
 import type { Mushroom } from "../types";
 
+const mushroomImage = (fileName: string) => `/images/mushrooms/${fileName}`;
+
 export const MUSHROOMS: Mushroom[] = [
   {
     id: "cepe_de_bordeaux",
@@ -59,20 +61,21 @@ export const MUSHROOMS: Mushroom[] = [
     photo: "https://images.unsplash.com/photo-1587307360679-f20b5cbd9e03?q=80&w=1600&auto=format&fit=crop"
   },
   { id: "morille_conique", name: "Morille conique", latin: "Morchella conica", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "morille_delicieuse", name: "Morille délicieuse", latin: "Morchella deliciosa", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Morchella_deliciosa.png") },
   { id: "cepe_d_ete", name: "Cèpe d'été", latin: "Boletus reticulatus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "cepe_des_pins", name: "Cèpe des pins", latin: "Boletus pinophilus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "cepe_bronze", name: "Cèpe bronze", latin: "Boletus aereus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "chanterelle_en_tube", name: "Chanterelle en tube", latin: "Cantharellus tubaeformis", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "trompette_de_la_mort", name: "Trompette de la mort", latin: "Craterellus cornucopioides", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "pied_de_mouton", name: "Pied-de-mouton", latin: "Hydnum repandum", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "trompette_de_la_mort", name: "Trompette de la mort", latin: "Craterellus cornucopioides", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Craterellus_cornucopioides.png") },
+  { id: "pied_de_mouton", name: "Pied-de-mouton", latin: "Hydnum repandum", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Hydnum_repandum.png") },
   { id: "lactaire_delicieux", name: "Lactaire délicieux", latin: "Lactarius deliciosus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "oronge", name: "Oronge", latin: "Amanita caesarea", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "pleurote_en_huitre", name: "Pleurote en huître", latin: "Pleurotus ostreatus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "pholiote_du_peuplier", name: "Pholiote du peuplier", latin: "Agrocybe aegerita", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "oronge", name: "Oronge", latin: "Amanita caesarea", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Amanita_caesarea.png") },
+  { id: "pleurote_en_huitre", name: "Pleurote en huître", latin: "Pleurotus ostreatus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Pleurotus_ostreatus.png") },
+  { id: "pholiote_du_peuplier", name: "Pholiote du peuplier", latin: "Cyclocybe cylindracea (Agrocybe aegerita)", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Cyclocybe_cylindracea.png") },
   { id: "lepiote_elevee", name: "Lépiote élevée", latin: "Macrolepiota procera", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "bolet_jaune", name: "Bolet jaune", latin: "Suillus luteus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "sparassis_crepu", name: "Sparassis crépu", latin: "Sparassis crispa", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "sparassis_crepu", name: "Sparassis crépu", latin: "Sparassis crispa", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Sparassis_crispa.png") },
   { id: "bolet_bai", name: "Bolet bai", latin: "Imleria badia", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "collybie_pied_veloute", name: "Collybie à pied velouté", latin: "Flammulina velutipes", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "truffe_noire", name: "Truffe noire", latin: "Tuber melanosporum", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" }
+  { id: "truffe_noire", name: "Truffe noire", latin: "Tuber melanosporum", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Tuber_melanosporum.png") }
 ];


### PR DESCRIPTION
### Motivation

- Provide local `public/images/mushrooms` PNGs to the species list so cards display app-bundled images instead of empty `photo` fields or external URLs.
- Add a missing species entry for the new `Morchella_deliciosa.png` image so it appears in the picker.

### Description

- Added a helper `mushroomImage(fileName)` and inserted it in `src/data/mushrooms.ts` to build image URLs from `public/images/mushrooms`.
- Replaced empty `photo` fields for several species with `mushroomImage("<file>.png")` for `Craterellus_cornucopioides`, `Hydnum_repandum`, `Amanita_caesarea`, `Pleurotus_ostreatus`, `Cyclocybe_cylindracea`, `Sparassis_crispa` and `Tuber_melanosporum`.
- Added a new entry `morille_delicieuse` (`Morchella deliciosa`) that references `Morchella_deliciosa.png`.
- Updated the pholiote entry to use the latin name `Cyclocybe cylindracea (Agrocybe aegerita)`.

### Testing

- Tried `npm test -- --runInBand`, which failed because Vitest does not accept the Jest `--runInBand` option.
- Ran `npm test`, which completed successfully: `Test Files 13 passed (13)` and `Tests 34 passed (34)`.
- Ran `npm run build`, which completed successfully with a production build from Vite (build succeeded, with a chunk size warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae9d089cc8329bef19dcf32fab770)