### PR TITLE
Fix GPS marker initialization order

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -535,13 +535,14 @@ export default function MapScene({
       const marker = new maplibreRef.current.Marker({
         element: container,
         anchor: "center",
-      }).addTo(mapRef.current);
+      });
+      marker
+        .setLngLat([userPosition.lng, userPosition.lat])
+        .addTo(mapRef.current);
       positionMarkerRef.current = marker;
+    } else {
+      positionMarkerRef.current.setLngLat([userPosition.lng, userPosition.lat]);
     }
-
-    positionMarkerRef.current
-      ?.setLngLat([userPosition.lng, userPosition.lat])
-      .addTo(mapRef.current);
 
     updateMarkerHeading(heading);
   }, [

--- a/src/scenes/__tests__/MapScene.test.tsx
+++ b/src/scenes/__tests__/MapScene.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { vi, describe, it, expect } from "vitest";
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
 import MapScene, { getNextMushroomSelection } from "../MapScene";
 import { AppProvider } from "@/context/AppContext";
@@ -28,6 +28,7 @@ vi.mock("framer-motion", () => ({
 }));
 
 let mapInstance: any;
+let markerInstances: any[] = [];
 
 // Mock OpenStreetMap services
 vi.mock("../../services/openstreetmap", () => {
@@ -52,13 +53,28 @@ vi.mock("../../services/openstreetmap", () => {
     fitBounds() {}
   }
   class Marker {
-    constructor() {}
+    options: any;
+    lngLatSet = false;
+    addToCalls = 0;
+
+    constructor(options?: any) {
+      this.options = options;
+      markerInstances.push(this);
+    }
+
     setLngLat() {
+      this.lngLatSet = true;
       return this;
     }
+
     addTo() {
+      if (!this.lngLatSet) {
+        throw new Error("Marker added before coordinates were set");
+      }
+      this.addToCalls += 1;
       return this;
     }
+
     remove() {}
   }
   return {
@@ -70,6 +86,11 @@ vi.mock("../../services/openstreetmap", () => {
 });
 
 describe("MapScene", () => {
+  beforeEach(() => {
+    mapInstance = undefined;
+    markerInstances = [];
+  });
+
   it("keeps GPS inactive until the user explicitly taps the GPS button", () => {
     const watchPosition = vi.fn();
     const setGpsFollow = vi.fn();
@@ -137,6 +158,52 @@ describe("MapScene", () => {
     ).toBeInTheDocument();
     expect(watchPosition).not.toHaveBeenCalled();
     expect(setGpsFollow).toHaveBeenCalledWith(false);
+  });
+
+  it("sets GPS marker coordinates before adding it to the map", async () => {
+    const watchPosition = vi.fn((success) => {
+      success({
+        coords: {
+          latitude: 48.8566,
+          longitude: 2.3522,
+          accuracy: 12,
+        },
+      });
+      return 7;
+    });
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: {
+        watchPosition,
+        clearWatch: vi.fn(),
+      },
+    });
+
+    render(
+      <AppProvider>
+        <MapScene
+          onZone={() => {}}
+          gpsFollow={true}
+          setGpsFollow={() => {}}
+          onBack={() => {}}
+        />
+      </AppProvider>,
+    );
+
+    await waitFor(() => {
+      const gpsMarker = markerInstances.find(
+        (marker) => marker.options?.anchor === "center",
+      );
+
+      expect(gpsMarker).toBeDefined();
+      expect(gpsMarker.lngLatSet).toBe(true);
+      expect(gpsMarker.addToCalls).toBe(1);
+    });
   });
 
   it("keeps only the three most recently activated mushroom maps", () => {


### PR DESCRIPTION
### Motivation
- The GPS marker was being added to MapLibre before its coordinates were set, which can trigger a runtime exception when MapLibre tries to render a marker without a position.

### Description
- In `src/scenes/MapScene.tsx` the GPS marker is now constructed, `setLngLat(...)` is applied before calling `addTo(...)`, and subsequent updates only call `setLngLat(...)` without re-adding the marker to the map.
- The test mock for `Marker` was strengthened to track whether `setLngLat()` was called and to throw if `addTo()` is invoked before coordinates are set, preventing false-positive tests.
- A regression test was added (`src/scenes/__tests__/MapScene.test.tsx`) that simulates a successful `watchPosition` callback and asserts the marker was given coordinates before being added to the map.

### Testing
- Ran the focused test suite with `npm test -- --run src/scenes/__tests__/MapScene.test.tsx` and it passed (8 tests).
- Ran the full test suite with `npm test` and all tests passed (13 files, 36 tests).
- Built the production bundle with `npm run build`; the build completed successfully (with chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af218ccc08329b9e9efff8a205c8b)