### PR TITLE
Link local mushroom images to species entries

### DIFF
--- a/src/data/mushrooms.ts
+++ b/src/data/mushrooms.ts
@@ -39,7 +39,7 @@ export const MUSHROOMS: Mushroom[] = [
     dishes: ["Risotto aux girolles", "Volaille sauce girolles", "Tartine forestière", "Pickles de girolles"],
     confusions: ["Clitocybe de l'olivier (toxique)", "Fausse girolle (Hygrophoropsis aurantiaca)",],
     picking: "Prélever les plus développées, laisser les jeunes",
-    photo: "https://images.unsplash.com/photo-1631460615580-bbbc9efeb800?q=80&w=1600&auto=format&fit=crop"
+    photo: mushroomImage("Cantharellus_cibarius.png")
   },
   {
     id: "morille_commune",
@@ -58,24 +58,24 @@ export const MUSHROOMS: Mushroom[] = [
     dishes: ["Morilles à la crème", "Poulet aux morilles", "Pâtes aux morilles", "Tartes salées aux morilles"],
     confusions: ["Gyromitre (toxique)", "Morillons (autres Morchella)",],
     picking: "Gants recommandés pour la cueillette; longue cuisson obligatoire",
-    photo: "https://images.unsplash.com/photo-1587307360679-f20b5cbd9e03?q=80&w=1600&auto=format&fit=crop"
+    photo: mushroomImage("Morchella_esculenta.png")
   },
   { id: "morille_conique", name: "Morille conique", latin: "Morchella conica", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "morille_delicieuse", name: "Morille délicieuse", latin: "Morchella deliciosa", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Morchella_deliciosa.png") },
   { id: "cepe_d_ete", name: "Cèpe d'été", latin: "Boletus reticulatus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "cepe_des_pins", name: "Cèpe des pins", latin: "Boletus pinophilus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "cepe_bronze", name: "Cèpe bronze", latin: "Boletus aereus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "chanterelle_en_tube", name: "Chanterelle en tube", latin: "Cantharellus tubaeformis", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "chanterelle_en_tube", name: "Chanterelle en tube", latin: "Cantharellus tubaeformis", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Craterellus_tubaeformis.png") },
   { id: "trompette_de_la_mort", name: "Trompette de la mort", latin: "Craterellus cornucopioides", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Craterellus_cornucopioides.png") },
   { id: "pied_de_mouton", name: "Pied-de-mouton", latin: "Hydnum repandum", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Hydnum_repandum.png") },
-  { id: "lactaire_delicieux", name: "Lactaire délicieux", latin: "Lactarius deliciosus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "lactaire_delicieux", name: "Lactaire délicieux", latin: "Lactarius deliciosus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Lactarius_deliciosus.png") },
   { id: "oronge", name: "Oronge", latin: "Amanita caesarea", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Amanita_caesarea.png") },
   { id: "pleurote_en_huitre", name: "Pleurote en huître", latin: "Pleurotus ostreatus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Pleurotus_ostreatus.png") },
   { id: "pholiote_du_peuplier", name: "Pholiote du peuplier", latin: "Cyclocybe cylindracea (Agrocybe aegerita)", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Cyclocybe_cylindracea.png") },
-  { id: "lepiote_elevee", name: "Lépiote élevée", latin: "Macrolepiota procera", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "lepiote_elevee", name: "Lépiote élevée", latin: "Macrolepiota procera", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Macrolepiota_procera.png") },
   { id: "bolet_jaune", name: "Bolet jaune", latin: "Suillus luteus", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
   { id: "sparassis_crepu", name: "Sparassis crépu", latin: "Sparassis crispa", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Sparassis_crispa.png") },
   { id: "bolet_bai", name: "Bolet bai", latin: "Imleria badia", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
-  { id: "collybie_pied_veloute", name: "Collybie à pied velouté", latin: "Flammulina velutipes", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: "" },
+  { id: "collybie_pied_veloute", name: "Collybie à pied velouté", latin: "Flammulina velutipes", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Flammulina_velutipes.png") },
   { id: "truffe_noire", name: "Truffe noire", latin: "Tuber melanosporum", edible: true, season: "", habitat: "", weatherIdeal: "", description: "", culinary: "", cookingTips: "", dishes: [], confusions: [], picking: "", photo: mushroomImage("Tuber_melanosporum.png") }
 ];


### PR DESCRIPTION
### Motivation
- Replace remote or empty `photo` values with bundled local images so species cards and detail views use the app's `/images/mushrooms/...` assets.

### Description
- Updated `src/data/mushrooms.ts` to use `mushroomImage("...")` for the following species: `Cantharellus_cibarius`, `Morchella_esculenta`, `Craterellus_tubaeformis` (chanterelle_en_tube), `Lactarius_deliciosus`, `Macrolepiota_procera`, and `Flammulina_velutipes` by replacing remote URLs or empty strings with local asset references.

### Testing
- `npm test` was run and all tests passed (`36 passed`).
- `npm test -- --runInBand` was attempted and failed because Vitest does not recognize the `--runInBand` option.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c15c2e0248329ba72e2421ac825df)