### PR TITLE
Remove GPS cart logo outline

### DIFF
--- a/src/scenes/MapScene.tsx
+++ b/src/scenes/MapScene.tsx
@@ -527,8 +527,7 @@ export default function MapScene({
       const positionLogo = document.createElement("img");
       positionLogo.src = logoPanier;
       positionLogo.alt = "Position GPS";
-      positionLogo.className =
-        "h-8 w-8 rounded-full border-2 border-white bg-white object-contain p-0.5 shadow-[0_0_0_6px_rgba(34,197,94,0.28)]";
+      positionLogo.className = "h-8 w-8 object-contain";
 
       container.appendChild(direction);
       container.appendChild(positionLogo);


### PR DESCRIPTION
### Motivation
- Remove the white circular background, border and glow around the GPS cart marker so the map shows only the cart logo without a surrounding outline.

### Description
- Update `src/scenes/MapScene.tsx` to change `positionLogo.className` from the rounded/bordered/bg/padded/shadow classes to `"h-8 w-8 object-contain"`, leaving the image element as the sole visible marker.

### Testing
- Ran `npm test -- --run src/scenes/__tests__/MapScene.test.tsx` and the Vitest suite for that file passed; `npm run build` completed successfully (with standard bundle-size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c166ea0cc8329aa73e3c4b1fc5104)