### PR TITLE
Zone: carrousel de détail avec carte interactive

### DIFF
--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -1,16 +1,16 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useRef } from "react";
 import { motion } from "framer-motion";
 import {
-  Car,
   ChevronLeft,
   ChevronRight,
   CloudSun,
   Droplets,
-  Heart,
   Leaf,
   MapPin,
-  Mountain,
+  Maximize2,
   Navigation,
+  Plus,
+  Route,
   ShieldCheck,
   Wind,
 } from "lucide-react";
@@ -29,6 +29,8 @@ import { MUSHROOMS } from "../data/mushrooms";
 import { generateForecast } from "../utils";
 import { useT } from "../i18n";
 import { useAppContext } from "../context/AppContext";
+import { getStaticMapUrl } from "../services/openstreetmap";
+import Logo from "@/assets/logo.png";
 import type { Zone } from "../types";
 
 export default function ZoneScene({
@@ -44,6 +46,7 @@ export default function ZoneScene({
 }) {
   const { t } = useT();
   const { state } = useAppContext();
+  const carouselRef = useRef<HTMLDivElement>(null);
   const data = useMemo(() => generateForecast(state.prefs.lang), [zone?.id, state.prefs.lang]);
 
   if (!zone) {
@@ -72,7 +75,18 @@ export default function ZoneScene({
       score,
     }))
     .filter((entry) => entry.mushroom);
-  const trendLabel = "Score stable";
+  const trendLabel = zone.trend || "Score stable";
+  const [lat, lng] = zone.coords;
+  const formattedCoords = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+  const staticMapUrl = getStaticMapUrl(lat, lng, 520, 260, 13);
+  const openMap = () => {
+    window.open(`https://www.openstreetmap.org/?mlat=${lat}&mlon=${lng}#map=15/${lat}/${lng}`, "_blank");
+  };
+  const scrollCarousel = (direction: -1 | 1) => {
+    const node = carouselRef.current;
+    if (!node) return;
+    node.scrollBy({ left: direction * node.clientWidth, behavior: "smooth" });
+  };
 
   return (
     <motion.section
@@ -88,52 +102,68 @@ export default function ZoneScene({
               <ChevronLeft className="h-8 w-8" />
             </button>
             <button onClick={onAdd} aria-label={t("Enregistrer")} className="rounded-full p-2 transition hover:bg-emerald-50">
-              <Heart className="h-8 w-8" />
+              <Plus className="h-8 w-8" />
             </button>
           </div>
           <div>
             <h1 className="font-serif text-6xl font-black leading-none tracking-tight text-[#00472d] sm:text-7xl">{zone.name}</h1>
             <div className="mt-6 flex flex-wrap items-center gap-4 text-base text-[#12223b] sm:text-lg">
-              <span className="inline-flex items-center gap-2"><MapPin className="h-6 w-6" /> Secteur Grenoble sud</span>
+              <span className="inline-flex items-center gap-2"><MapPin className="h-5 w-5" /> {zone.name}</span>
               <span>•</span>
-              <span className="inline-flex items-center gap-2"><Car className="h-6 w-6" /> 12 min</span>
-              <span>•</span>
-              <span className="inline-flex items-center gap-2"><Mountain className="h-6 w-6" /> Alt. 320 m</span>
+              <span className="inline-flex items-center gap-2"><Navigation className="h-5 w-5" /> {formattedCoords}</span>
             </div>
           </div>
         </header>
 
         <section className="relative">
-          <button aria-label="Zone précédente" className="absolute -left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white p-3 text-[#00472d] shadow-lg sm:-left-6">
-            <ChevronLeft className="h-7 w-7" />
+          <button type="button" onClick={() => scrollCarousel(-1)} aria-label="Carte précédente" className="absolute -left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white p-3 text-[#00472d] shadow-lg sm:-left-6">
+            <ChevronLeft className="h-6 w-6" />
           </button>
-          <button aria-label="Zone suivante" className="absolute -right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white p-3 text-[#00472d] shadow-lg sm:-right-6">
-            <ChevronRight className="h-7 w-7" />
+          <button type="button" onClick={() => scrollCarousel(1)} aria-label="Carte suivante" className="absolute -right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white p-3 text-[#00472d] shadow-lg sm:-right-6">
+            <ChevronRight className="h-6 w-6" />
           </button>
-          <div className="grid gap-6 rounded-[1.75rem] border border-[#eee6da] bg-white/90 p-6 shadow-[0_18px_50px_-32px_rgba(15,23,42,0.7)] md:grid-cols-[1fr_1px_1fr] md:p-10">
-            <div className="flex flex-col items-center justify-center text-center">
-              <p className="text-2xl font-extrabold text-[#00472d]">{trendLabel || "Score stable"}</p>
-              <div className="mt-2 text-7xl font-black leading-none text-[#00472d] sm:text-8xl">{displayedScore}<span className="text-5xl">%</span></div>
-              <p className="mt-2 max-w-xs text-2xl leading-tight">Estimation générale<br />de la zone</p>
-              <span className="mt-5 inline-flex items-center gap-2 rounded-full bg-[#eaf2e3] px-5 py-2 text-sm font-semibold text-[#00472d]"><Leaf className="h-5 w-5" /> Version gratuite</span>
-            </div>
-            <div className="hidden bg-[#e7dfd4] md:block" />
-            <div className="flex flex-col justify-center">
-              <div className="grid grid-cols-[auto_1fr] items-center gap-6 border-b border-[#e7dfd4] pb-6">
-                <CloudSun className="h-28 w-28 text-amber-400" />
-                <div>
-                  <div className="text-6xl font-black text-[#00472d]">18°</div>
-                  <div className="mt-2 text-xl text-[#536078]">Nuageux</div>
-                </div>
+          <div ref={carouselRef} className="flex snap-x snap-mandatory gap-5 overflow-x-auto scroll-smooth pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <div className="grid min-w-full snap-center gap-5 rounded-3xl border border-border bg-paper p-5 shadow-sm md:grid-cols-2 md:p-6">
+              <div className="flex flex-col items-center justify-center text-center">
+                <p className="text-lg font-semibold text-forest">{trendLabel}</p>
+                <div className="mt-1 text-6xl font-black leading-none text-forest sm:text-7xl">{displayedScore}<span className="text-3xl">%</span></div>
+                <p className="mt-2 max-w-xs text-base leading-tight text-foreground/80">Estimation générale<br />de la zone</p>
+                <span className="mt-4 inline-flex items-center gap-2 rounded-full bg-forest/10 px-4 py-2 text-xs font-medium text-forest"><Leaf className="h-4 w-4" /> Version gratuite</span>
               </div>
-              <div className="grid gap-4 pt-5 text-xl text-[#536078]">
-                <div className="flex items-center justify-between"><span className="inline-flex items-center gap-3"><Droplets className="h-6 w-6" /> Humidité</span><span className="font-semibold text-[#10213a]">68%</span></div>
-                <div className="flex items-center justify-between"><span className="inline-flex items-center gap-3"><Wind className="h-6 w-6" /> Vent</span><span className="font-semibold text-[#10213a]">8 km/h</span></div>
+              <div className="relative min-h-56 overflow-hidden rounded-2xl border border-border bg-secondary">
+                <img src={staticMapUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
+                <img src={Logo} alt="" className="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-full" />
+                <button type="button" onClick={openMap} aria-label="Agrandir la carte" className="absolute right-3 top-3 rounded-full bg-paper/90 p-2 text-forest shadow-sm transition hover:bg-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
+                  <Maximize2 className="h-5 w-5" />
+                </button>
+              </div>
+            </div>
+
+            <div className="grid min-w-full snap-center gap-5 rounded-3xl border border-border bg-paper p-5 shadow-sm md:grid-cols-2 md:p-6">
+              <div className="flex flex-col items-center justify-center text-center">
+                <p className="text-lg font-semibold text-forest">Potentiel du jour</p>
+                <div className="mt-1 text-6xl font-black leading-none text-forest sm:text-7xl">{displayedScore}<span className="text-3xl">%</span></div>
+                <p className="mt-2 text-sm text-foreground/70">Score de base {Math.max(0, displayedScore - 6)}% · Météo +6 pts</p>
+                <span className="mt-4 inline-flex items-center gap-2 rounded-full bg-forest/10 px-4 py-2 text-xs font-medium text-forest"><Leaf className="h-4 w-4" /> Conditions favorables</span>
+              </div>
+              <div className="flex flex-col justify-center rounded-2xl border border-border p-5">
+                <div className="grid grid-cols-[auto_1fr] items-center gap-5 border-b border-border pb-5">
+                  <CloudSun className="h-20 w-20 text-amber-400" />
+                  <div>
+                    <div className="text-5xl font-black text-forest">18°</div>
+                    <div className="mt-1 text-sm text-foreground/70">Nuageux</div>
+                  </div>
+                </div>
+                <div className="grid gap-3 pt-4 text-sm text-foreground/70">
+                  <div className="flex items-center justify-between"><span className="inline-flex items-center gap-2"><Droplets className="h-4 w-4" /> Humidité</span><span className="font-medium text-foreground">68%</span></div>
+                  <div className="flex items-center justify-between"><span className="inline-flex items-center gap-2"><Wind className="h-4 w-4" /> Vent</span><span className="font-medium text-foreground">8 km/h</span></div>
+                </div>
               </div>
             </div>
           </div>
-          <div className="mt-4 flex justify-center gap-4">
-            {[0, 1, 2, 3, 4].map((dot) => <span key={dot} className={`h-3 w-3 rounded-full ${dot === 0 ? "bg-[#00472d]" : "bg-[#d8d3c9]"}`} />)}
+          <div className="mt-3 flex justify-center gap-3">
+            <span className="h-2.5 w-2.5 rounded-full bg-forest" />
+            <span className="h-2.5 w-2.5 rounded-full bg-border" />
           </div>
         </section>
 
@@ -185,10 +215,10 @@ export default function ZoneScene({
           <div><p className="text-xl font-extrabold text-[#00472d]">Rappel sécurité</p><p className="text-[#536078]">Ne consommez jamais un champignon sans identification certaine.</p></div>
         </div>
 
-        <footer className="grid gap-4 md:grid-cols-2">
-          <button onClick={openDirections} className="flex items-center justify-center gap-5 rounded-2xl bg-[#00472d] px-6 py-5 text-xl font-extrabold text-white shadow-lg transition hover:bg-[#00603d]"><Navigation className="h-9 w-9" /><span className="text-left">Me guider<br /><span className="text-base font-medium">Voir l'itinéraire</span></span></button>
-          <button onClick={onAdd} className="flex items-center justify-center gap-5 rounded-2xl border-2 border-[#00472d] px-6 py-5 text-xl font-extrabold text-[#00472d] transition hover:bg-emerald-50"><Heart className="h-9 w-9" /> Enregistrer</button>
-          <p className="text-sm text-[#7787a3] md:col-span-2">Source météo : Météo-France · Mise à jour le 12/07 à 08:00</p>
+        <footer className="flex flex-wrap items-center gap-3">
+          <button onClick={openDirections} className="inline-flex items-center justify-center gap-2 rounded-full bg-forest px-5 py-3 text-sm font-semibold text-paper shadow-sm transition hover:bg-moss focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"><Route className="h-5 w-5" /> Me guider</button>
+          <button onClick={onAdd} className="inline-flex items-center justify-center gap-2 rounded-full bg-forest px-5 py-3 text-sm font-semibold text-paper shadow-sm transition hover:bg-moss focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"><Plus className="h-5 w-5" /> Ajouter à mes coins</button>
+          <p className="basis-full text-xs text-foreground/50">Source météo : Météo-France · Mise à jour le 12/07 à 08:00</p>
         </footer>
       </div>
     </motion.section>


### PR DESCRIPTION
### Motivation
- Remplacer le bloc statique score/météo par un carrousel contenant la valeur stable et une carte, pour correspondre au comportement attendu lors d'un clic sur la carte. 
- Afficher les vraies valeurs de la zone (nom et coordonnées) au lieu d'exemples et harmoniser les actions avec le style global de l'application.

### Description
- Modifié `src/scenes/ZoneScene.tsx` pour remplacer le panneau score/météo par un carrousel horizontal à deux cartes et ajouter des contrôles de défilement (`carouselRef` + `scrollCarousel`).
- Intégré une carte statique générée via `getStaticMapUrl` et centré le logo champignon (`Logo`) sur la carte, avec un bouton d'agrandissement ouvrant l'emplacement sur OpenStreetMap via `openMap`.
- Remplacé les textes d'exemple (`Secteur Grenoble sud`, `12 min`, `Alt. 320 m`) par le nom de la zone et des coordonnées formatées (`zone.name` et `formattedCoords` issu de `zone.coords`).
- Adapté les boutons d'action pour utiliser le style existant (boutons verts arrondis) et les libellés/icônes demandés (`Me guider` et `Ajouter à mes coins`), et utilisé `zone.trend || "Score stable"` pour le libellé de tendance.

### Testing
- Exécuté `npm run build`, la compilation a réussi sans erreur (vite build completed).
- Vérification de format/whitespace via `git diff --check` a été passée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53784901308329992eff07b22f406a)