### PR TITLE
Revamp zone detail screen

### DIFF
--- a/src/scenes/ZoneScene.tsx
+++ b/src/scenes/ZoneScene.tsx
@@ -1,26 +1,21 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import {
+  Bookmark,
   ChevronLeft,
-  ChevronRight,
-  CloudSun,
-  Droplets,
+  CloudRain,
+  Compass,
+  Expand,
   Leaf,
-  Maximize2,
-  Route,
+  Lock,
+  MapPin,
   ShieldCheck,
-  Wind,
+  Sprout,
 } from "lucide-react";
 import {
   Area,
   AreaChart,
-  CartesianGrid,
-  ReferenceDot,
-  ReferenceLine,
   ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
 } from "recharts";
 import { MUSHROOMS } from "../data/mushrooms";
 import { generateForecast } from "../utils";
@@ -33,7 +28,7 @@ import type { Zone } from "../types";
 export default function ZoneScene({
   zone,
   onAdd,
-  onOpenShroom,
+  onOpenShroom: _onOpenShroom,
   onBack,
   onOpenMap,
 }: {
@@ -45,185 +40,129 @@ export default function ZoneScene({
 }) {
   const { t } = useT();
   const { state } = useAppContext();
-  const carouselRef = useRef<HTMLDivElement>(null);
-  const [activeSlide, setActiveSlide] = useState(0);
   const data = useMemo(() => generateForecast(state.prefs.lang), [zone?.id, state.prefs.lang]);
-
-  const scrollCarousel = (direction: -1 | 1) => {
-    const node = carouselRef.current;
-    if (!node) return;
-    const next = (activeSlide + direction + 2) % 2;
-    node.scrollTo({ left: next * node.clientWidth, behavior: "smooth" });
-    setActiveSlide(next);
-  };
-
-  useEffect(() => {
-    const node = carouselRef.current;
-    if (!node) return;
-    const handleScroll = () => {
-      const next = Math.round(node.scrollLeft / Math.max(1, node.clientWidth));
-      setActiveSlide(Math.max(0, Math.min(1, next)));
-    };
-    node.addEventListener("scroll", handleScroll, { passive: true });
-    return () => node.removeEventListener("scroll", handleScroll);
-  }, []);
+  const [selectedSpeciesId, setSelectedSpeciesId] = useState<string | null>(null);
 
   if (!zone) {
     return <div className="p-6 text-slate-900">{t("Sélectionnez une zone…")}</div>;
   }
 
-  const openDirections = () => {
-    if (!zone?.coords) return;
-    const [lat, lng] = zone.coords;
-    window.open(`https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`, "_blank");
-  };
-
-  const todayIndex = Math.min(5, data.length - 1);
-  const displayedScore = zone.score;
-  const forecastData = data.slice(2, 13).map((point, index) => ({
-    ...point,
-    day: index === todayIndex ? "Aujourd'hui" : point.day,
-    score: index === todayIndex ? displayedScore : point.score,
-  }));
-  const currentForecast = forecastData[todayIndex];
-  const likelySpecies = Object.entries(zone.species as Record<string, number>)
+  const speciesScores = Object.entries(zone.species as Record<string, number>)
     .filter(([, score]) => score > 0)
     .sort(([, a], [, b]) => b - a)
-    .slice(0, 3)
-    .map(([id, score]) => ({
-      mushroom: MUSHROOMS.find((m) => m.id === id),
-      score,
-    }))
+    .map(([id, score]) => ({ mushroom: MUSHROOMS.find((m) => m.id === id), score }))
     .filter((entry) => entry.mushroom);
+  const visibleSpecies = speciesScores.slice(0, 3);
+  const selectedSpecies =
+    speciesScores.find(({ mushroom }) => mushroom!.id === selectedSpeciesId) ?? speciesScores[0];
+  const mushroom = selectedSpecies?.mushroom ?? MUSHROOMS[0];
+  const baseScore = selectedSpecies?.score ?? zone.score;
+  const adjustedScore = Math.min(99, baseScore + 7);
+  const lockedData = data.slice(0, 10).map((point, index) => ({
+    ...point,
+    score: Math.max(10, Math.min(96, baseScore - 8 + index * 2 + (index % 3) * 3)),
+  }));
   const [lat, lng] = zone.coords;
-  const staticMapUrl = getStaticMapUrl(lat, lng, 520, 260, 13);
-  const openMap = () => onOpenMap(zone);
+  const staticMapUrl = getStaticMapUrl(lat, lng, 520, 190, 14);
+
+  const openDirections = () => {
+    window.open(`https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`, "_blank");
+  };
 
   return (
     <motion.section
       initial={{ x: 20, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -20, opacity: 0 }}
-      className="min-h-screen bg-[#fbf8f1] px-5 py-7 text-[#10213a] sm:px-8"
+      className="min-h-screen bg-[#fbf8f1] px-4 py-7 text-[#003f2a] sm:px-8"
     >
-      <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-5xl flex-col gap-6 rounded-[2rem] bg-gradient-to-br from-white via-[#fffdf7] to-[#f6f1e8] p-5 shadow-[0_25px_80px_-50px_rgba(15,23,42,0.55)] sm:p-8">
-        <header className="space-y-5">
-          <div className="flex items-center justify-between text-[#00472d]">
-            <button onClick={onBack} aria-label={t("Retour")} className="rounded-full p-2 transition hover:bg-emerald-50">
-              <ChevronLeft className="h-8 w-8" />
-            </button>
-            <span className="h-12 w-12" aria-hidden />
-          </div>
-          <div className="-mt-4 text-center sm:-mt-8">
-            <h1 className="font-serif text-5xl font-black leading-none tracking-tight text-[#00472d] sm:text-7xl">{zone.name}</h1>
-          </div>
+      <div className="mx-auto w-full max-w-6xl space-y-5">
+        <header className="relative pb-2 text-center">
+          <button onClick={onBack} aria-label={t("Retour")} className="absolute left-0 top-1 rounded-full p-2 text-[#003f2a] transition hover:bg-emerald-50">
+            <ChevronLeft className="h-8 w-8 stroke-[2.5]" />
+          </button>
+          <h1 className="font-serif text-5xl font-black leading-none tracking-tight sm:text-7xl">{zone.name}</h1>
         </header>
 
-        <section className="relative">
-          <button type="button" onClick={() => scrollCarousel(-1)} aria-label="Carte précédente" className="absolute -left-4 top-1/2 z-10 -translate-y-1/2 rounded-full border border-forest/15 bg-white p-3.5 text-[#00472d] shadow-[0_14px_34px_-12px_rgba(15,35,58,0.7)] ring-4 ring-white/70 transition hover:scale-105 hover:bg-emerald-50 sm:-left-8">
-            <ChevronLeft className="h-7 w-7 stroke-[3]" />
-          </button>
-          <button type="button" onClick={() => scrollCarousel(1)} aria-label="Carte suivante" className="absolute -right-4 top-1/2 z-10 -translate-y-1/2 rounded-full border border-forest/15 bg-white p-3.5 text-[#00472d] shadow-[0_14px_34px_-12px_rgba(15,35,58,0.7)] ring-4 ring-white/70 transition hover:scale-105 hover:bg-emerald-50 sm:-right-8">
-            <ChevronRight className="h-7 w-7 stroke-[3]" />
-          </button>
-          <div ref={carouselRef} className="flex snap-x snap-mandatory gap-5 overflow-x-auto scroll-smooth pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            <div className="grid min-w-full snap-center gap-5 rounded-3xl border border-border bg-white p-5 shadow-sm md:grid-cols-2 md:p-6">
-              <div className="flex flex-col items-center justify-center text-center">
-                <div className="mt-1 text-6xl font-black leading-none text-forest sm:text-7xl">{displayedScore}<span className="text-3xl">%</span></div>
-                <p className="mt-2 max-w-xs text-base leading-tight text-foreground/80">Estimation générale<br />de la zone</p>
-                <span className="mt-4 inline-flex items-center gap-2 rounded-full bg-forest/10 px-4 py-2 text-xs font-medium text-forest"><Leaf className="h-4 w-4" /> Version gratuite</span>
-              </div>
-              <div className="relative min-h-56 overflow-hidden rounded-2xl border border-border bg-secondary">
-                <img src={staticMapUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
-                <img src={Logo} alt="" className="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-full" />
-                <button type="button" onClick={openMap} aria-label="Agrandir la carte" className="absolute right-3 top-3 rounded-full bg-paper/90 p-2 text-forest shadow-sm transition hover:bg-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
-                  <Maximize2 className="h-5 w-5" />
-                </button>
-              </div>
-            </div>
-
-            <div className="grid min-w-full snap-center gap-5 rounded-3xl border border-border bg-white p-5 shadow-sm md:grid-cols-2 md:p-6">
-              <div className="flex flex-col items-center justify-center text-center md:border-r md:border-border/80 md:pr-6">
-                <p className="text-xl font-extrabold uppercase tracking-[0.18em] text-forest sm:text-2xl">Potentiel du jour</p>
-                <div className="mt-2 text-7xl font-black leading-none text-forest sm:text-8xl">{displayedScore}<span className="text-4xl sm:text-5xl">%</span></div>
-                <p className="mt-3 text-base font-semibold text-foreground/70 sm:text-lg">Score de base {Math.max(0, displayedScore - 6)}% · Météo +6 pts</p>
-                <span className="mt-5 inline-flex items-center gap-2 rounded-full bg-forest/10 px-5 py-2.5 text-sm font-bold text-forest"><Leaf className="h-5 w-5" /> Conditions favorables</span>
-              </div>
-              <div className="flex flex-col justify-center rounded-2xl p-5 md:pl-6">
-                <div className="grid grid-cols-[auto_1fr] items-center gap-5 border-b border-border pb-5">
-                  <CloudSun className="h-20 w-20 text-amber-400" />
-                  <div>
-                    <div className="text-5xl font-black text-forest">18°</div>
-                    <div className="mt-1 text-sm text-foreground/70">Nuageux</div>
-                  </div>
-                </div>
-                <div className="grid gap-3 pt-4 text-sm text-foreground/70">
-                  <div className="flex items-center justify-between"><span className="inline-flex items-center gap-2"><Droplets className="h-4 w-4" /> Humidité</span><span className="font-medium text-foreground">68%</span></div>
-                  <div className="flex items-center justify-between"><span className="inline-flex items-center gap-2"><Wind className="h-4 w-4" /> Vent</span><span className="font-medium text-foreground">8 km/h</span></div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="mt-3 flex justify-center gap-3">
-            {[0, 1].map((index) => (
-              <span key={index} className={`h-2.5 w-2.5 rounded-full transition-colors ${activeSlide === index ? "bg-forest" : "bg-border"}`} />
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-[1.75rem] border border-[#eee6da] bg-white/90 p-5 shadow-[0_18px_50px_-36px_rgba(15,23,42,0.65)] sm:p-8">
-          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-            <h2 className="text-2xl font-extrabold text-[#00472d]">Évolution sur 10 jours</h2>
-          </div>
-          <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={forecastData} margin={{ top: 22, right: 8, bottom: 0, left: -18 }}>
-                <defs><linearGradient id="zoneScore" x1="0" x2="0" y1="0" y2="1"><stop offset="0%" stopColor="#75a957" stopOpacity={0.35} /><stop offset="100%" stopColor="#75a957" stopOpacity={0.04} /></linearGradient></defs>
-                <CartesianGrid stroke="#e8dfd2" strokeDasharray="4 4" vertical={false} />
-                <XAxis dataKey="day" tick={{ fill: "#536078", fontSize: 14 }} axisLine={{ stroke: "#e8dfd2" }} tickLine={false} />
-                <YAxis domain={[0, 100]} ticks={[0, 25, 50, 75, 100]} tickFormatter={(value) => `${value}%`} tick={{ fill: "#536078", fontSize: 14 }} axisLine={false} tickLine={false} />
-                <Tooltip formatter={(value) => [`${value}%`, "Score"]} contentStyle={{ borderRadius: 14, border: "1px solid #e8dfd2" }} />
-                <ReferenceLine x={currentForecast.day} stroke="#0f6b45" />
-                <ReferenceDot x={currentForecast.day} y={displayedScore} r={0} label={{ value: `${displayedScore}%`, position: "top", fill: "#fff", fontSize: 18, fontWeight: 800, offset: 10 }} />
-                <Area type="monotone" dataKey="score" stroke="#2e7d32" strokeWidth={3} fill="url(#zoneScore)" dot={{ r: 4, strokeWidth: 3, fill: "#fff", stroke: "#0b6b2a" }} activeDot={{ r: 6 }} />
-              </AreaChart>
-            </ResponsiveContainer>
-          </div>
-        </section>
-
-        <section>
-          <h2 className="mb-4 text-2xl font-extrabold text-[#00472d]">Espèces potentiellement présentes</h2>
-          <div className="grid gap-5 md:grid-cols-3">
-            {likelySpecies.map(({ mushroom, score }) => {
-              const level = score >= 75 ? "élevé" : score >= 50 ? "moyen" : "faible";
-              const color = score >= 75 ? "text-[#0a6842] bg-[#e7f1df]" : score >= 50 ? "text-[#a36300] bg-[#fff1d2]" : "text-[#f04a17] bg-[#fff0db]";
+        <section className="space-y-4">
+          <h2 className="text-2xl font-extrabold">Choisir un champignon</h2>
+          <div className="flex gap-4 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            {visibleSpecies.map(({ mushroom: species }) => {
+              const active = species!.id === mushroom.id;
               return (
-                <button key={mushroom!.id} onClick={() => onOpenShroom(mushroom!.id)} className="overflow-hidden rounded-2xl border border-[#eee6da] bg-white text-left shadow-sm transition hover:-translate-y-1 hover:shadow-xl">
-                  <img src={mushroom!.photo} alt="" className="h-44 w-full object-cover" />
-                  <div className="p-4">
-                    <h3 className="text-2xl font-extrabold">{mushroom!.name}</h3>
-                    <p className="text-lg italic text-[#536078]">{mushroom!.latin}</p>
-                    <div className="my-4 border-t border-[#eee6da]" />
-                    <p className="text-sm text-[#536078]">Potentiel de présence</p>
-                    <div className="mt-1 flex items-center justify-between"><span className={`text-4xl font-black ${score >= 75 ? "text-[#0a6842]" : score >= 50 ? "text-[#f0a11a]" : "text-[#f04a17]"}`}>{score}%</span><span className={`rounded-full px-4 py-2 text-sm font-semibold ${color}`}>{level}</span></div>
-                  </div>
+                <button
+                  key={species!.id}
+                  onClick={() => setSelectedSpeciesId(species!.id)}
+                  className={`flex shrink-0 items-center gap-3 rounded-[1.45rem] border bg-white px-7 py-4 text-xl shadow-[0_12px_28px_-20px_rgba(15,23,42,0.65)] transition ${active ? "border-[#003f2a] font-extrabold ring-1 ring-[#003f2a]" : "border-[#eee6da] hover:border-[#9eb6a8]"}`}
+                >
+                  <img src={species!.photo} alt="" className="h-9 w-9 rounded-full object-cover" />
+                  {species!.name}
                 </button>
               );
             })}
+            {speciesScores.length > 3 && (
+              <button className="shrink-0 rounded-[1.45rem] border border-[#eee6da] bg-white px-8 py-4 text-xl shadow-[0_12px_28px_-20px_rgba(15,23,42,0.65)]">+{speciesScores.length - 3}</button>
+            )}
           </div>
         </section>
 
-        <div className="flex items-center gap-5 rounded-2xl bg-white/75 px-5 py-4 shadow-sm">
-          <ShieldCheck className="h-14 w-14 shrink-0 text-[#00472d]" />
-          <div><p className="text-xl font-extrabold text-[#00472d]">Rappel sécurité</p><p className="text-[#536078]">Ne consommez jamais un champignon sans identification certaine.</p></div>
-        </div>
+        <section className="grid gap-7 rounded-[1.75rem] bg-white p-5 shadow-[0_22px_70px_-46px_rgba(15,23,42,0.75)] md:grid-cols-[0.95fr_1.05fr]">
+          <img src={mushroom.photo} alt={mushroom.name} className="h-full min-h-[420px] w-full rounded-[1.35rem] object-cover" />
+          <div className="space-y-5 py-3">
+            <div>
+              <h2 className="font-serif text-5xl font-black leading-tight">{mushroom.name}</h2>
+              <p className="text-2xl italic text-[#6e7177]">{mushroom.latin}</p>
+            </div>
 
-        <footer className="flex flex-wrap items-center gap-3">
-          <button onClick={openDirections} className="inline-flex items-center justify-center gap-2 rounded-full bg-forest px-5 py-3 text-sm font-semibold text-paper shadow-sm transition hover:bg-moss focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"><Route className="h-5 w-5" /> Me guider</button>
-          <button onClick={onAdd} className="inline-flex items-center justify-center rounded-full bg-forest px-5 py-3 text-sm font-semibold text-paper shadow-sm transition hover:bg-moss focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">Ajouter à mes coins</button>
-          <p className="basis-full text-xs text-foreground/50">Source météo : Météo-France · Mise à jour le 12/07 à 08:00</p>
+            <div className="rounded-3xl border-2 border-[#00472d] p-7">
+              <div className="flex items-center justify-between gap-3"><h3 className="text-2xl font-extrabold">Score de base</h3><span className="rounded-full bg-[#e8eee0] px-4 py-2 font-bold">Gratuit</span></div>
+              <div className="mt-4 text-8xl font-black leading-none">{baseScore}<span className="text-5xl">%</span></div>
+              <p className="mt-4 flex items-center gap-3 text-2xl"><Leaf className="h-7 w-7" /> Conditions naturelles</p>
+            </div>
+
+            <div className="relative overflow-hidden rounded-3xl bg-[#f0eee8] p-7">
+              <div className="absolute right-5 top-5 z-10 flex items-center gap-2 rounded-full bg-white/55 px-4 py-2 font-bold"><Lock className="h-5 w-5" /> Premium</div>
+              <div className="blur-[7px]">
+                <h3 className="text-2xl font-extrabold">Score ajusté météo</h3>
+                <div className="mt-5 flex items-center justify-between"><span className="text-8xl font-black">{adjustedScore}%</span><div className="h-32 w-32 rounded-full border-[14px] border-[#7fb28e]" /></div>
+              </div>
+              <div className="absolute inset-0 flex flex-col items-center justify-center pt-10 text-center"><Lock className="h-10 w-10 rounded-full bg-[#00472d] p-2 text-white" /><p className="text-2xl font-extrabold">Premium</p><p>Débloquez avec Premium</p></div>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-5 md:grid-cols-2">
+          <InfoCard title="Carte" icon={<MapPin className="h-8 w-8" />} action={<Expand className="h-6 w-6" />} onClick={() => onOpenMap(zone)}>
+            <div className="relative h-40 overflow-hidden rounded-2xl bg-[#eef1ea]"><img src={staticMapUrl} alt="" className="h-full w-full object-cover opacity-75" /><img src={Logo} alt="" className="absolute left-1/2 top-1/2 h-12 w-12 -translate-x-1/2 -translate-y-1/2" /></div>
+          </InfoCard>
+          <InfoCard title="Météo" icon={<CloudRain className="h-9 w-9" />}>
+            <div className="grid gap-3 text-xl"><p className="text-6xl font-black">18°C</p><p className="flex items-center gap-3"><CloudRain className="h-6 w-6" /> Pluie</p><p className="flex items-center gap-3"><Sprout className="h-6 w-6" /> Humidité 82%</p></div>
+          </InfoCard>
+        </section>
+
+        <section className="relative overflow-hidden rounded-[1.5rem] bg-white p-6 shadow-[0_18px_50px_-38px_rgba(15,23,42,0.75)]">
+          <div className="mb-2 flex items-center justify-between"><h2 className="text-2xl font-extrabold">Évolution sur 10 jours</h2><span className="flex items-center gap-2 rounded-full bg-[#eeeae2] px-4 py-2 font-bold"><Lock className="h-5 w-5" /> Premium</span></div>
+          <div className="h-44 blur-[6px]"><ResponsiveContainer width="100%" height="100%"><AreaChart data={lockedData}><Area type="monotone" dataKey="score" stroke="#2e7d32" strokeWidth={4} fill="#e7f1df" /></AreaChart></ResponsiveContainer></div>
+          <div className="absolute inset-0 flex flex-col items-center justify-center pt-10"><Lock className="h-10 w-10 rounded-full bg-[#00472d] p-2 text-white" /><p className="text-2xl font-extrabold">Premium</p><p>Débloquez avec Premium</p></div>
+        </section>
+
+        <div className="flex items-center gap-5 rounded-[1.5rem] bg-white px-7 py-5 shadow-sm"><ShieldCheck className="h-14 w-14 shrink-0 fill-[#1e7c3e] text-[#1e7c3e]" /><div><p className="text-2xl font-extrabold">Rappel sécurité</p><p className="text-lg text-[#536078]">Ne consommez jamais un champignon sans identification certaine.</p></div></div>
+
+        <footer className="grid gap-4 sm:grid-cols-2">
+          <button onClick={openDirections} className="inline-flex items-center justify-center gap-3 rounded-2xl bg-[#00472d] px-6 py-5 text-xl font-extrabold text-white shadow-sm"><Compass className="h-8 w-8" /> Me guider</button>
+          <button onClick={onAdd} className="inline-flex items-center justify-center gap-3 rounded-2xl bg-[#00472d] px-6 py-5 text-xl font-extrabold text-white shadow-sm"><Bookmark className="h-8 w-8" /> Ajouter à mes coins</button>
+          <p className="text-center text-sm text-[#7a818b] sm:col-span-2">Source météo : Météo-France · Mise à jour le 12/07 à 08:00</p>
         </footer>
       </div>
     </motion.section>
+  );
+}
+
+function InfoCard({ title, icon, action, onClick, children }: { title: string; icon: React.ReactNode; action?: React.ReactNode; onClick?: () => void; children: React.ReactNode }) {
+  return (
+    <section className="rounded-[1.5rem] bg-white p-5 shadow-[0_18px_50px_-38px_rgba(15,23,42,0.75)]">
+      <div className="mb-4 flex items-center justify-between text-[#003f2a]"><h2 className="flex items-center gap-4 text-2xl font-extrabold">{icon}{title}</h2>{action && <button onClick={onClick} className="rounded-full p-2 hover:bg-emerald-50">{action}</button>}</div>
+      {children}
+    </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the zone (coin) detail view match the requested mockup when a user taps a zone on the map by surfacing likely species, a large mushroom profile, and premium-locked weather/forecast information.
- Provide a clearer, more tactile selection flow for species within a zone so the displayed mushroom and base score update when a species chip is tapped.

### Description
- Reworked `src/scenes/ZoneScene.tsx` to replace the old two-panel carousel with a centered header, species picker chips, and a large mushroom profile card that updates based on a new `selectedSpeciesId` state.
- Introduced `speciesScores`, `visibleSpecies`, `selectedSpecies`, `baseScore`, `adjustedScore`, and `lockedData` to compute per-species base and previewed premium scores and a blurred locked 10-day chart.
- Added compact `InfoCard` component and mini map/weather cards (map opens via the existing `onOpenMap` callback) and kept the Google Maps `Me guider` action wired to the zone coordinates (`openDirections`).
- Cleaned up unused carousel/refs and simplified imports, adjusted static map parameters, and visually marked premium areas with blurred/locked overlays.

### Testing
- Ran `npm run build` and the production build completed successfully. (success)
- Ran `npm test` and all existing unit tests passed: 13 test files, 36 tests (success).
- Running `npm test -- --runInBand` fails as expected because Vitest does not accept Jest's `--runInBand` option (expected failure).
- Attempted `npx playwright screenshot` and `npx playwright install chromium` to capture a runtime screenshot, but Playwright browser installation failed due to CDN `403 Domain forbidden` so headless screenshots could not be produced (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53deefe8108329af6586f7e08f37bc)